### PR TITLE
ci: build multi-arch image (amd64/arm64) and tag with commit sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
           echo "owner_lower=$OWNER_LOWER" >> "$GITHUB_OUTPUT"
           echo "image_repo=${{ env.REGISTRY }}/$OWNER_LOWER/${{ env.IMAGE_NAME }}" >> "$GITHUB_OUTPUT"
       
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v4
       
       - name: Log in to GitHub Container Registry
@@ -69,6 +71,7 @@ jobs:
           context: .
           file: Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha,scope=${{ env.IMAGE_NAME }}
           cache-to: type=gha,mode=max,scope=${{ env.IMAGE_NAME }}
           tags: |
@@ -94,10 +97,10 @@ jobs:
           set -euo pipefail
           
           IMAGE_REPO="${{ needs.build-and-push.outputs.image_repo }}"
-          DIGEST="${{ needs.build-and-push.outputs.digest }}"
+          SHORT_SHA="${{ needs.build-and-push.outputs.short_sha }}"
           
           export IMAGE_REPO
-          export OGOUNE_IMAGE="${IMAGE_REPO}@${DIGEST}"
+          export OGOUNE_IMAGE="${IMAGE_REPO}:${SHORT_SHA}"
 
           yq -i ".services.ogoune.image = \"${OGOUNE_IMAGE}\"" docker-compose.yml
           


### PR DESCRIPTION
This pull request updates the CI workflow to improve Docker image building and deployment. The main changes ensure multi-platform builds, update the way images are tagged and referenced, and add support for QEMU emulation.

**Docker build and deployment improvements:**

* Added the `docker/setup-qemu-action@v3` step to enable cross-platform builds in the workflow (`.github/workflows/ci.yml`).
* Configured the Docker build to produce multi-platform images for both `linux/amd64` and `linux/arm64` (`.github/workflows/ci.yml`).
* Changed the image tagging from using the digest to using the short SHA, and updated the `OGOUNE_IMAGE` environment variable to reference the image by tag instead of digest (`.github/workflows/ci.yml`).