### PR TITLE
broker protocol checks

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/038-resource-service-split"
+  "feature_directory": "specs/039-broker-protocol-checks"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,5 +190,5 @@ Before completing any task or commit, you MUST:
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/028-protocol-auth-variants/plan.md`
+`specs/039-broker-protocol-checks/plan.md`
 <!-- SPECKIT END -->

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Set `confirmation_checks: 1` to restore immediate alerts.
 | ICMP ping checks | Optional host reachability monitoring when the runtime has raw-socket capability |
 | Heartbeat / Push monitoring | Verify cron jobs and background workers actually ran |
 | Keyword / content check monitor | Verify response body contains (or does not contain) a string — catches HTTP 200s with degraded content |
-| Protocol-aware monitors | Redis (PING + optional `AUTH`), MongoDB (BSON hello), FTP, SSH, MySQL & PostgreSQL (TCP fallback or authenticated handshake). TLS is auto-detected from the target URL (`rediss://`, `?tls=true`, `sslmode=require`). Credentials are encrypted at rest with AES-256-GCM. |
+| Protocol-aware monitors | Redis (PING + optional `AUTH`), MongoDB (BSON hello), FTP, SSH, MySQL & PostgreSQL (TCP fallback or authenticated handshake), RabbitMQ (AMQP 0-9-1 `connection.start` handshake), Kafka (Metadata Request v1 against a comma-separated bootstrap broker list with sequential failover). TLS is auto-detected from the target URL (`rediss://`, `?tls=true`, `sslmode=require`). Credentials are encrypted at rest with AES-256-GCM. |
 | SSL expiry warnings | Get notified before certs expire |
 | Domain expiry warnings | Get notified before domains expire |
 | Confirmation window | N consecutive failures before alerting |

--- a/internal/monitoring/strategy/protocol.go
+++ b/internal/monitoring/strategy/protocol.go
@@ -74,6 +74,14 @@ var protocolHandlers = map[string]protocolHandler{
 		defaultPort: 5432,
 		customExec:  postgresCheck,
 	},
+	"rabbitmq": {
+		defaultPort: 5672,
+		customExec:  rabbitmqCheck,
+	},
+	"kafka": {
+		defaultPort: 9092,
+		customExec:  kafkaCheck,
+	},
 }
 
 // validBSONResponse returns true when the response looks like a successful MongoDB reply:

--- a/internal/monitoring/strategy/protocol_kafka.go
+++ b/internal/monitoring/strategy/protocol_kafka.go
@@ -1,0 +1,237 @@
+package strategy
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/denisakp/ogoune/internal/domain"
+)
+
+const (
+	kafkaAPIKeyMetadata    = int16(3)
+	kafkaAPIVersion        = int16(1)
+	kafkaCorrelationID     = int32(1)
+	kafkaClientID          = "ogoune-monitor"
+	kafkaMaxResponseSize   = 1 * 1024 * 1024
+	kafkaMaxStringLen      = 64 * 1024
+	kafkaDefaultPerBroker  = 5 * time.Second
+)
+
+// parseKafkaBootstrap splits a comma-separated `host:port` list, trims whitespace,
+// validates each entry via net.SplitHostPort, and returns the normalized addresses.
+// Returns error if no valid entries remain.
+func parseKafkaBootstrap(target string) ([]string, error) {
+	if strings.TrimSpace(target) == "" {
+		return nil, fmt.Errorf("empty bootstrap target")
+	}
+	parts := strings.Split(target, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		s := strings.TrimSpace(p)
+		if s == "" {
+			continue
+		}
+		host, port, err := net.SplitHostPort(s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid bootstrap entry %q: %v", s, err)
+		}
+		if host == "" || port == "" {
+			return nil, fmt.Errorf("invalid bootstrap entry %q", s)
+		}
+		out = append(out, net.JoinHostPort(host, port))
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no bootstrap entries parsed from %q", target)
+	}
+	return out, nil
+}
+
+// kafkaCheck sends a Metadata Request v1 (brokers-only, topics=-1) to each bootstrap
+// broker sequentially with per-broker timeout. First successful response wins; if all
+// fail, the last failure cause is reported.
+func kafkaCheck(ctx context.Context, r *domain.Resource, host string, port int, useTLS bool, timeout time.Duration, dial DialFunc) domain.CheckResult {
+	bootstraps, err := parseKafkaBootstrap(r.Target)
+	if err != nil {
+		cause := domain.InvalidConfiguration
+		return domain.CheckResult{
+			Status:       string(domain.StatusDown),
+			ResponseData: err.Error(),
+			Cause:        &cause,
+		}
+	}
+
+	perBrokerTimeout := timeout
+	if perBrokerTimeout <= 0 {
+		perBrokerTimeout = kafkaDefaultPerBroker
+	}
+
+	start := time.Now()
+	req := buildKafkaMetadataRequest()
+
+	var last domain.CheckResult
+	for _, addr := range bootstraps {
+		last = kafkaProbeBroker(ctx, addr, perBrokerTimeout, req, dial, start)
+		if last.Status == string(domain.StatusUp) {
+			return last
+		}
+	}
+	return last
+}
+
+func kafkaProbeBroker(ctx context.Context, addr string, timeout time.Duration, req []byte, dial DialFunc, start time.Time) domain.CheckResult {
+	dialCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	conn, err := dial(dialCtx, "tcp", addr)
+	if err != nil {
+		return dialError(ctx, addr, err, start)
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+
+	if _, err := conn.Write(req); err != nil {
+		return kafkaProtocolFail(addr, fmt.Sprintf("write failed: %v", err), start)
+	}
+
+	sizeBuf := make([]byte, 4)
+	n, err := io.ReadFull(conn, sizeBuf)
+	if err != nil {
+		if n == 0 {
+			// Connection closed cleanly with zero bytes — Kafka behavior when SASL required.
+			cause := domain.ProtocolAuthFailed
+			return domain.CheckResult{
+				Status:       string(domain.StatusDown),
+				ResponseTime: time.Since(start),
+				ResponseData: fmt.Sprintf("authentication_required: broker closed connection without reply (%s)", addr),
+				Cause:        &cause,
+			}
+		}
+		if isTimeoutErr(err) {
+			cause := domain.ConnectionTimeout
+			return domain.CheckResult{
+				Status:       string(domain.StatusDown),
+				ResponseTime: time.Since(start),
+				ResponseData: fmt.Sprintf("timeout reading metadata response from %s", addr),
+				Cause:        &cause,
+			}
+		}
+		return kafkaProtocolFail(addr, fmt.Sprintf("truncated response: %v", err), start)
+	}
+	size := int32(binary.BigEndian.Uint32(sizeBuf))
+	if size < 4 || size > kafkaMaxResponseSize {
+		return kafkaProtocolFail(addr, fmt.Sprintf("response size %d out of range", size), start)
+	}
+
+	body := make([]byte, int(size))
+	if _, err := io.ReadFull(conn, body); err != nil {
+		return kafkaProtocolFail(addr, fmt.Sprintf("truncated body: %v", err), start)
+	}
+
+	// correlation_id (int32) — must match request.
+	if len(body) < 4 {
+		return kafkaProtocolFail(addr, "response too short for correlation_id", start)
+	}
+	cid := int32(binary.BigEndian.Uint32(body[0:4]))
+	if cid != kafkaCorrelationID {
+		return kafkaProtocolFail(addr, fmt.Sprintf("correlation_id mismatch: got %d", cid), start)
+	}
+
+	// brokers array (int32 count + entries)
+	if len(body) < 8 {
+		return kafkaProtocolFail(addr, "response missing brokers array", start)
+	}
+	brokerCount := int32(binary.BigEndian.Uint32(body[4:8]))
+	if brokerCount < 1 {
+		return kafkaProtocolFail(addr, "brokers count = 0 (broker advertises empty cluster)", start)
+	}
+	if brokerCount > 65535 {
+		return kafkaProtocolFail(addr, fmt.Sprintf("implausible broker count %d", brokerCount), start)
+	}
+
+	// Sanity-walk first broker entry to ensure string lengths are bounded.
+	off := 8
+	if !kafkaWalkBroker(body, &off) {
+		return kafkaProtocolFail(addr, "malformed broker entry (string length overflow)", start)
+	}
+
+	return domain.CheckResult{
+		Status:       string(domain.StatusUp),
+		ResponseTime: time.Since(start),
+		ResponseData: fmt.Sprintf("Metadata Response v1 received from %s; %d brokers advertised", addr, brokerCount),
+	}
+}
+
+// kafkaWalkBroker advances off through one Broker record (node_id int32, host string,
+// port int32, rack nullable_string). Returns false on overflow / bounds failure.
+func kafkaWalkBroker(body []byte, off *int) bool {
+	if *off+4 > len(body) {
+		return false
+	}
+	*off += 4 // node_id
+	// host string
+	if *off+2 > len(body) {
+		return false
+	}
+	hostLen := int(int16(binary.BigEndian.Uint16(body[*off : *off+2])))
+	*off += 2
+	if hostLen < 0 || hostLen > kafkaMaxStringLen || *off+hostLen > len(body) {
+		return false
+	}
+	*off += hostLen
+	if *off+4 > len(body) {
+		return false
+	}
+	*off += 4 // port
+	// rack nullable_string
+	if *off+2 > len(body) {
+		return false
+	}
+	rackLen := int(int16(binary.BigEndian.Uint16(body[*off : *off+2])))
+	*off += 2
+	if rackLen > kafkaMaxStringLen {
+		return false
+	}
+	if rackLen > 0 {
+		if *off+rackLen > len(body) {
+			return false
+		}
+		*off += rackLen
+	}
+	return true
+}
+
+// buildKafkaMetadataRequest constructs a Metadata Request v1 with topics=-1.
+func buildKafkaMetadataRequest() []byte {
+	clientID := []byte(kafkaClientID)
+	bodyLen := 2 + 2 + 4 + (2 + len(clientID)) + 4
+	out := make([]byte, 4+bodyLen)
+	binary.BigEndian.PutUint32(out[0:4], uint32(bodyLen))
+	o := 4
+	binary.BigEndian.PutUint16(out[o:o+2], uint16(kafkaAPIKeyMetadata))
+	o += 2
+	binary.BigEndian.PutUint16(out[o:o+2], uint16(kafkaAPIVersion))
+	o += 2
+	binary.BigEndian.PutUint32(out[o:o+4], uint32(kafkaCorrelationID))
+	o += 4
+	binary.BigEndian.PutUint16(out[o:o+2], uint16(len(clientID)))
+	o += 2
+	copy(out[o:o+len(clientID)], clientID)
+	o += len(clientID)
+	// topics count = -1
+	binary.BigEndian.PutUint32(out[o:o+4], 0xFFFFFFFF)
+	return out
+}
+
+func kafkaProtocolFail(addr, msg string, start time.Time) domain.CheckResult {
+	cause := domain.ProtocolHandshakeFailed
+	return domain.CheckResult{
+		Status:       string(domain.StatusDown),
+		ResponseTime: time.Since(start),
+		ResponseData: fmt.Sprintf("protocol_handshake_failed at %s: %s", addr, msg),
+		Cause:        &cause,
+	}
+}

--- a/internal/monitoring/strategy/protocol_kafka_integration_test.go
+++ b/internal/monitoring/strategy/protocol_kafka_integration_test.go
@@ -1,0 +1,40 @@
+//go:build integration
+
+package strategy
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/denisakp/ogoune/internal/domain"
+	"github.com/stretchr/testify/require"
+)
+
+// TestKafka_Integration runs against a real Kafka broker.
+//
+// Setup (KRaft single node):
+//   docker run --rm -d -p 9092:9092 --name ogoune-it-kafka apache/kafka:3.7.0
+//
+// Run:
+//   OGOUNE_INTEGRATION=1 go test -tags=integration -run Kafka_Integration \
+//     ./internal/monitoring/strategy/...
+func TestKafka_Integration(t *testing.T) {
+	if os.Getenv("OGOUNE_INTEGRATION") != "1" {
+		t.Skip("OGOUNE_INTEGRATION=1 required")
+	}
+	host := envDefault("KAFKA_HOST", "127.0.0.1")
+	addr := net.JoinHostPort(host, "9092")
+
+	if c, err := net.DialTimeout("tcp", addr, 2*time.Second); err != nil {
+		t.Skipf("no Kafka reachable at %s: %v", addr, err)
+	} else {
+		c.Close()
+	}
+
+	r := newKafkaResource(addr, 5)
+	res := kafkaCheck(context.Background(), r, "", 0, false, 5*time.Second, unsafeDialer)
+	require.Equal(t, string(domain.StatusUp), res.Status, "ResponseData=%s", res.ResponseData)
+}

--- a/internal/monitoring/strategy/protocol_kafka_test.go
+++ b/internal/monitoring/strategy/protocol_kafka_test.go
@@ -1,0 +1,197 @@
+package strategy
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denisakp/ogoune/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// readKafkaRequest reads the size-prefixed request bytes from conn.
+func readKafkaRequest(conn net.Conn) ([]byte, error) {
+	sz := make([]byte, 4)
+	if _, err := io.ReadFull(conn, sz); err != nil {
+		return nil, err
+	}
+	n := binary.BigEndian.Uint32(sz)
+	body := make([]byte, int(n))
+	if _, err := io.ReadFull(conn, body); err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+// buildMetadataResponseV1 builds a minimal valid Metadata Response v1 with `nBrokers` broker entries.
+func buildMetadataResponseV1(corrID int32, nBrokers int) []byte {
+	body := bytes.NewBuffer(nil)
+	binary.Write(body, binary.BigEndian, corrID)
+	binary.Write(body, binary.BigEndian, int32(nBrokers))
+	for i := 0; i < nBrokers; i++ {
+		binary.Write(body, binary.BigEndian, int32(i)) // node_id
+		host := fmt.Sprintf("broker-%d", i)
+		binary.Write(body, binary.BigEndian, int16(len(host)))
+		body.WriteString(host)
+		binary.Write(body, binary.BigEndian, int32(9092)) // port
+		binary.Write(body, binary.BigEndian, int16(-1))   // rack = null
+	}
+	binary.Write(body, binary.BigEndian, int32(0))  // controller_id
+	binary.Write(body, binary.BigEndian, int32(0))  // topics count = 0
+	out := bytes.NewBuffer(nil)
+	binary.Write(out, binary.BigEndian, int32(body.Len()))
+	out.Write(body.Bytes())
+	return out.Bytes()
+}
+
+func newKafkaResource(target string, timeoutSec int) *domain.Resource {
+	pt := "kafka"
+	return &domain.Resource{Target: target, Timeout: timeoutSec, ProtocolType: &pt}
+}
+
+func TestKafka_Happy_SingleBroker(t *testing.T) {
+	host, port := startMockTCP(t, func(conn net.Conn) {
+		_, _ = readKafkaRequest(conn)
+		conn.Write(buildMetadataResponseV1(1, 3))
+	})
+	r := newKafkaResource(net.JoinHostPort(host, fmt.Sprint(port)), 2)
+	res := kafkaCheck(context.Background(), r, "", 0, false, 2*time.Second, unsafeDialer)
+	assert.Equal(t, string(domain.StatusUp), res.Status)
+	assert.Contains(t, res.ResponseData, "3 brokers")
+}
+
+func TestKafka_MultiBootstrap_FirstUnreachable(t *testing.T) {
+	host, port := startMockTCP(t, func(conn net.Conn) {
+		_, _ = readKafkaRequest(conn)
+		conn.Write(buildMetadataResponseV1(1, 1))
+	})
+	target := fmt.Sprintf("127.0.0.1:1,%s", net.JoinHostPort(host, fmt.Sprint(port)))
+	r := newKafkaResource(target, 2)
+	res := kafkaCheck(context.Background(), r, "", 0, false, 2*time.Second, unsafeDialer)
+	assert.Equal(t, string(domain.StatusUp), res.Status)
+}
+
+func TestKafka_AllUnreachable(t *testing.T) {
+	r := newKafkaResource("127.0.0.1:1,127.0.0.1:2", 1)
+	res := kafkaCheck(context.Background(), r, "", 0, false, 500*time.Millisecond, unsafeDialer)
+	assert.Equal(t, string(domain.StatusDown), res.Status)
+	require.NotNil(t, res.Cause)
+}
+
+func TestKafka_CorrelationIDMismatch(t *testing.T) {
+	host, port := startMockTCP(t, func(conn net.Conn) {
+		_, _ = readKafkaRequest(conn)
+		conn.Write(buildMetadataResponseV1(42, 1))
+	})
+	r := newKafkaResource(net.JoinHostPort(host, fmt.Sprint(port)), 1)
+	res := kafkaCheck(context.Background(), r, "", 0, false, 1*time.Second, unsafeDialer)
+	assert.Equal(t, string(domain.StatusDown), res.Status)
+	require.NotNil(t, res.Cause)
+	assert.Equal(t, domain.ProtocolHandshakeFailed, *res.Cause)
+}
+
+func TestKafka_ZeroBrokers(t *testing.T) {
+	host, port := startMockTCP(t, func(conn net.Conn) {
+		_, _ = readKafkaRequest(conn)
+		conn.Write(buildMetadataResponseV1(1, 0))
+	})
+	r := newKafkaResource(net.JoinHostPort(host, fmt.Sprint(port)), 1)
+	res := kafkaCheck(context.Background(), r, "", 0, false, 1*time.Second, unsafeDialer)
+	assert.Equal(t, string(domain.StatusDown), res.Status)
+	require.NotNil(t, res.Cause)
+	assert.Equal(t, domain.ProtocolHandshakeFailed, *res.Cause)
+}
+
+func TestKafka_ConnCloseAfterRequest_AuthRequired(t *testing.T) {
+	host, port := startMockTCP(t, func(conn net.Conn) {
+		_, _ = readKafkaRequest(conn)
+		conn.Close()
+	})
+	r := newKafkaResource(net.JoinHostPort(host, fmt.Sprint(port)), 1)
+	res := kafkaCheck(context.Background(), r, "", 0, false, 1*time.Second, unsafeDialer)
+	assert.Equal(t, string(domain.StatusDown), res.Status)
+	require.NotNil(t, res.Cause)
+	assert.Equal(t, domain.ProtocolAuthFailed, *res.Cause)
+}
+
+func TestKafka_OversizedResponse(t *testing.T) {
+	host, port := startMockTCP(t, func(conn net.Conn) {
+		_, _ = readKafkaRequest(conn)
+		// size = 2 MiB
+		binary.Write(conn, binary.BigEndian, int32(2*1024*1024))
+	})
+	r := newKafkaResource(net.JoinHostPort(host, fmt.Sprint(port)), 1)
+	res := kafkaCheck(context.Background(), r, "", 0, false, 1*time.Second, unsafeDialer)
+	assert.Equal(t, string(domain.StatusDown), res.Status)
+	require.NotNil(t, res.Cause)
+	assert.Equal(t, domain.ProtocolHandshakeFailed, *res.Cause)
+}
+
+func TestKafka_TLSNoise(t *testing.T) {
+	host, port := startMockTCP(t, func(conn net.Conn) {
+		_, _ = readKafkaRequest(conn)
+		conn.Write([]byte{0x16, 0x03, 0x03, 0x00, 0x40})
+		conn.Write(bytes.Repeat([]byte{0xAA}, 64))
+	})
+	r := newKafkaResource(net.JoinHostPort(host, fmt.Sprint(port)), 1)
+	res := kafkaCheck(context.Background(), r, "", 0, false, 1*time.Second, unsafeDialer)
+	assert.Equal(t, string(domain.StatusDown), res.Status)
+	require.NotNil(t, res.Cause)
+	assert.Equal(t, domain.ProtocolHandshakeFailed, *res.Cause)
+}
+
+func TestKafka_TimeoutDirectFromResource(t *testing.T) {
+	// per-broker timeout = resource.Timeout exactly (not divided by N)
+	cases := []struct {
+		timeout int
+		want    time.Duration
+	}{
+		{1, 1 * time.Second},
+		{2, 2 * time.Second},
+		{5, 5 * time.Second},
+	}
+	for _, c := range cases {
+		// We just assert the same value path; here we invoke check against unreachable host
+		// and ensure it returns quickly (within timeout * N + slack).
+		r := newKafkaResource("127.0.0.1:1", c.timeout)
+		start := time.Now()
+		_ = kafkaCheck(context.Background(), r, "", 0, false, c.want, unsafeDialer)
+		elapsed := time.Since(start)
+		assert.Less(t, elapsed, c.want+2*time.Second, "timeout=%d should bound elapsed", c.timeout)
+	}
+}
+
+func TestKafka_ParseBootstrap(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantLen int
+		wantErr bool
+	}{
+		{"h1:9092", 1, false},
+		{"h1:9092,h2:9092 , h3:9092", 3, false},
+		{"", 0, true},
+		{"h1", 0, true},
+		{",,", 0, true},
+		{"   ", 0, true},
+	}
+	for _, c := range cases {
+		got, err := parseKafkaBootstrap(c.in)
+		if c.wantErr {
+			require.Error(t, err, "input=%q", c.in)
+			continue
+		}
+		require.NoError(t, err, "input=%q", c.in)
+		assert.Len(t, got, c.wantLen)
+		for _, g := range got {
+			assert.NotContains(t, g, " ", "normalized entry %q should be trimmed", g)
+			assert.True(t, strings.Contains(g, ":"))
+		}
+	}
+}

--- a/internal/monitoring/strategy/protocol_rabbitmq.go
+++ b/internal/monitoring/strategy/protocol_rabbitmq.go
@@ -1,0 +1,157 @@
+package strategy
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/denisakp/ogoune/internal/domain"
+)
+
+// AMQP 0-9-1 protocol header preamble.
+var amqpProtocolHeader = []byte{'A', 'M', 'Q', 'P', 0x00, 0x00, 0x09, 0x01}
+
+const (
+	amqpMaxFrameSize  = 65536
+	amqpMethodFrame   = 0x01
+	amqpFrameEnd      = 0xCE
+	amqpClassConn     = 0x000A
+	amqpMethodStart   = 0x000A
+	amqpMethodClose   = 0x0032
+	amqpReplyAuth530  = 530
+	amqpReplyAuth403  = 403
+)
+
+// rabbitmqCheck performs an AMQP 0-9-1 protocol handshake. It sends the 8-byte
+// protocol header and expects the broker to reply with a connection.start method
+// frame. Reject is bounded: max 7-byte envelope + 65 KiB payload + 1 byte frame end.
+// Credentials are not supported (FR-009); auth-required brokers surface as
+// "authentication_required" via connection.close reply-code 530/403.
+func rabbitmqCheck(ctx context.Context, r *domain.Resource, host string, port int, useTLS bool, timeout time.Duration, dial DialFunc) domain.CheckResult {
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
+	start := time.Now()
+
+	dialCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	conn, err := dial(dialCtx, "tcp", addr)
+	if err != nil {
+		return dialError(ctx, addr, err, start)
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+
+	if _, err := conn.Write(amqpProtocolHeader); err != nil {
+		return rabbitmqProtocolFail(addr, fmt.Sprintf("failed to send AMQP header: %v", err), start)
+	}
+
+	// Peek first byte to detect AMQP 1.0 reply ('A') or TLS noise (0x16).
+	first := make([]byte, 1)
+	if _, err := io.ReadFull(conn, first); err != nil {
+		if isTimeoutErr(err) {
+			return rabbitmqTimeout(addr, start)
+		}
+		return rabbitmqProtocolFail(addr, fmt.Sprintf("connection closed before reply from %s", addr), start)
+	}
+
+	// AMQP 1.0 broker replies with 'A' 'M' 'Q' 'P' 0x00 0x01 0x00 0x00.
+	if first[0] == 'A' {
+		rest := make([]byte, 7)
+		_, _ = io.ReadFull(conn, rest) // best effort
+		return rabbitmqProtocolFail(addr, "broker replied with AMQP 1.0 protocol header; AMQP 0-9-1 unsupported", start)
+	}
+
+	if first[0] != amqpMethodFrame {
+		return rabbitmqProtocolFail(addr, fmt.Sprintf("unexpected first byte 0x%02x from %s (not AMQP method frame)", first[0], addr), start)
+	}
+
+	// Remaining 6 bytes of envelope: channel(2) + size(4)
+	envRest := make([]byte, 6)
+	if _, err := io.ReadFull(conn, envRest); err != nil {
+		if isTimeoutErr(err) {
+			return rabbitmqTimeout(addr, start)
+		}
+		return rabbitmqProtocolFail(addr, fmt.Sprintf("truncated AMQP envelope from %s: %v", addr, err), start)
+	}
+	size := binary.BigEndian.Uint32(envRest[2:6])
+	if size == 0 || size > amqpMaxFrameSize {
+		return rabbitmqProtocolFail(addr, fmt.Sprintf("AMQP frame size %d outside [1,%d]", size, amqpMaxFrameSize), start)
+	}
+
+	payload := make([]byte, int(size))
+	if _, err := io.ReadFull(conn, payload); err != nil {
+		if isTimeoutErr(err) {
+			return rabbitmqTimeout(addr, start)
+		}
+		return rabbitmqProtocolFail(addr, fmt.Sprintf("truncated AMQP payload from %s: %v", addr, err), start)
+	}
+	// Frame-end byte.
+	tail := make([]byte, 1)
+	if _, err := io.ReadFull(conn, tail); err != nil || tail[0] != amqpFrameEnd {
+		return rabbitmqProtocolFail(addr, fmt.Sprintf("invalid AMQP frame-end from %s", addr), start)
+	}
+
+	if len(payload) < 4 {
+		return rabbitmqProtocolFail(addr, "AMQP method payload too short", start)
+	}
+	classID := binary.BigEndian.Uint16(payload[0:2])
+	methodID := binary.BigEndian.Uint16(payload[2:4])
+
+	if classID == amqpClassConn && methodID == amqpMethodClose {
+		// reply-code is uint16 right after method id
+		var replyCode uint16
+		if len(payload) >= 6 {
+			replyCode = binary.BigEndian.Uint16(payload[4:6])
+		}
+		if replyCode == amqpReplyAuth530 || replyCode == amqpReplyAuth403 {
+			cause := domain.ProtocolAuthFailed
+			return domain.CheckResult{
+				Status:       string(domain.StatusDown),
+				ResponseTime: time.Since(start),
+				ResponseData: fmt.Sprintf("authentication_required: broker sent connection.close reply-code %d", replyCode),
+				Cause:        &cause,
+			}
+		}
+		return rabbitmqProtocolFail(addr, fmt.Sprintf("broker sent connection.close reply-code %d", replyCode), start)
+	}
+
+	if classID != amqpClassConn || methodID != amqpMethodStart {
+		return rabbitmqProtocolFail(addr, fmt.Sprintf("unexpected AMQP method class=%d method=%d", classID, methodID), start)
+	}
+
+	verMajor := uint8(0)
+	verMinor := uint8(9)
+	if len(payload) >= 6 {
+		verMajor = payload[4]
+		verMinor = payload[5]
+	}
+
+	return domain.CheckResult{
+		Status:       string(domain.StatusUp),
+		ResponseTime: time.Since(start),
+		ResponseData: fmt.Sprintf("AMQP %d-%d connection.start received from %s", verMajor, verMinor, addr),
+	}
+}
+
+func rabbitmqProtocolFail(addr, msg string, start time.Time) domain.CheckResult {
+	cause := domain.ProtocolHandshakeFailed
+	return domain.CheckResult{
+		Status:       string(domain.StatusDown),
+		ResponseTime: time.Since(start),
+		ResponseData: fmt.Sprintf("protocol_handshake_failed: %s", msg),
+		Cause:        &cause,
+	}
+}
+
+func rabbitmqTimeout(addr string, start time.Time) domain.CheckResult {
+	cause := domain.ConnectionTimeout
+	return domain.CheckResult{
+		Status:       string(domain.StatusDown),
+		ResponseTime: time.Since(start),
+		ResponseData: fmt.Sprintf("timeout waiting for AMQP reply from %s", addr),
+		Cause:        &cause,
+	}
+}

--- a/internal/monitoring/strategy/protocol_rabbitmq_integration_test.go
+++ b/internal/monitoring/strategy/protocol_rabbitmq_integration_test.go
@@ -1,0 +1,50 @@
+//go:build integration
+
+package strategy
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/denisakp/ogoune/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRabbitMQ_Integration runs against a real RabbitMQ broker.
+//
+// Setup (manual or compose):
+//   docker run --rm -d -p 5672:5672 --name ogoune-it-rabbit rabbitmq:3.13-management
+//
+// Run:
+//   OGOUNE_INTEGRATION=1 go test -tags=integration -run RabbitMQ_Integration \
+//     ./internal/monitoring/strategy/...
+func TestRabbitMQ_Integration(t *testing.T) {
+	if os.Getenv("OGOUNE_INTEGRATION") != "1" {
+		t.Skip("OGOUNE_INTEGRATION=1 required")
+	}
+	host := envDefault("RABBITMQ_HOST", "127.0.0.1")
+	port := 5672
+
+	// Probe reachability up-front; skip if no broker.
+	if c, err := net.DialTimeout("tcp", net.JoinHostPort(host, "5672"), 2*time.Second); err != nil {
+		t.Skipf("no RabbitMQ reachable at %s: %v", host, err)
+	} else {
+		c.Close()
+	}
+
+	r := protoResource(host, port, "rabbitmq")
+	res := rabbitmqCheck(context.Background(), r, host, port, false, 5*time.Second, unsafeDialer)
+	require.Equal(t, string(domain.StatusUp), res.Status, "ResponseData=%s", res.ResponseData)
+	assert.Contains(t, res.ResponseData, "AMQP")
+}
+
+func envDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/internal/monitoring/strategy/protocol_rabbitmq_test.go
+++ b/internal/monitoring/strategy/protocol_rabbitmq_test.go
@@ -1,0 +1,142 @@
+package strategy
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/denisakp/ogoune/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildConnectionStartFrame builds a minimal connection.start method frame.
+// reply is used for class+method when emulating a different frame.
+func buildConnectionStartFrame(verMajor, verMinor byte) []byte {
+	payload := []byte{
+		0x00, 0x0A, // class-id = 10 (connection)
+		0x00, 0x0A, // method-id = 10 (start)
+		verMajor, verMinor,
+		// minimal server-properties (empty long-string), mechanisms (empty long-string), locales (empty long-string)
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+	}
+	frame := bytes.NewBuffer(nil)
+	frame.WriteByte(0x01) // type METHOD
+	binary.Write(frame, binary.BigEndian, uint16(0))
+	binary.Write(frame, binary.BigEndian, uint32(len(payload)))
+	frame.Write(payload)
+	frame.WriteByte(0xCE)
+	return frame.Bytes()
+}
+
+func buildConnectionCloseFrame(replyCode uint16) []byte {
+	payload := []byte{
+		0x00, 0x0A, // class-id = 10
+		0x00, 0x32, // method-id = 50 (close)
+		byte(replyCode >> 8), byte(replyCode & 0xFF),
+		0x00, // reply-text shortstr len = 0
+		0x00, 0x00, // failing-class
+		0x00, 0x00, // failing-method
+	}
+	frame := bytes.NewBuffer(nil)
+	frame.WriteByte(0x01)
+	binary.Write(frame, binary.BigEndian, uint16(0))
+	binary.Write(frame, binary.BigEndian, uint32(len(payload)))
+	frame.Write(payload)
+	frame.WriteByte(0xCE)
+	return frame.Bytes()
+}
+
+func TestRabbitMQ_HappyPath(t *testing.T) {
+	host, port := startMockTCP(t, func(conn net.Conn) {
+		hdr := make([]byte, 8)
+		io.ReadFull(conn, hdr)
+		conn.Write(buildConnectionStartFrame(0, 9))
+	})
+	r := protoResource(host, port, "rabbitmq")
+	res := rabbitmqCheck(context.Background(), r, host, port, false, 2*time.Second, unsafeDialer)
+	assert.Equal(t, string(domain.StatusUp), res.Status)
+	assert.Contains(t, res.ResponseData, "AMQP 0-9")
+}
+
+func TestRabbitMQ_WrongProtocol(t *testing.T) {
+	host, port := startMockTCP(t, func(conn net.Conn) {
+		hdr := make([]byte, 8)
+		io.ReadFull(conn, hdr)
+		conn.Write([]byte("HTTP/1.1 200 OK\r\n\r\n"))
+	})
+	r := protoResource(host, port, "rabbitmq")
+	res := rabbitmqCheck(context.Background(), r, host, port, false, 1*time.Second, unsafeDialer)
+	assert.Equal(t, string(domain.StatusDown), res.Status)
+	require.NotNil(t, res.Cause)
+	assert.Equal(t, domain.ProtocolHandshakeFailed, *res.Cause)
+}
+
+func TestRabbitMQ_AMQP10Reply(t *testing.T) {
+	host, port := startMockTCP(t, func(conn net.Conn) {
+		hdr := make([]byte, 8)
+		io.ReadFull(conn, hdr)
+		conn.Write([]byte{'A', 'M', 'Q', 'P', 0x00, 0x01, 0x00, 0x00})
+	})
+	r := protoResource(host, port, "rabbitmq")
+	res := rabbitmqCheck(context.Background(), r, host, port, false, 1*time.Second, unsafeDialer)
+	assert.Equal(t, string(domain.StatusDown), res.Status)
+	require.NotNil(t, res.Cause)
+	assert.Equal(t, domain.ProtocolHandshakeFailed, *res.Cause)
+	assert.Contains(t, res.ResponseData, "AMQP 1.0")
+}
+
+func TestRabbitMQ_AuthRequired_Close530(t *testing.T) {
+	host, port := startMockTCP(t, func(conn net.Conn) {
+		hdr := make([]byte, 8)
+		io.ReadFull(conn, hdr)
+		conn.Write(buildConnectionCloseFrame(530))
+	})
+	r := protoResource(host, port, "rabbitmq")
+	res := rabbitmqCheck(context.Background(), r, host, port, false, 1*time.Second, unsafeDialer)
+	assert.Equal(t, string(domain.StatusDown), res.Status)
+	require.NotNil(t, res.Cause)
+	assert.Equal(t, domain.ProtocolAuthFailed, *res.Cause)
+}
+
+func TestRabbitMQ_Timeout(t *testing.T) {
+	host, port := startMockTCP(t, func(conn net.Conn) {
+		// read header then hang
+		hdr := make([]byte, 8)
+		io.ReadFull(conn, hdr)
+		time.Sleep(2 * time.Second)
+	})
+	r := protoResource(host, port, "rabbitmq")
+	res := rabbitmqCheck(context.Background(), r, host, port, false, 300*time.Millisecond, unsafeDialer)
+	assert.Equal(t, string(domain.StatusDown), res.Status)
+	require.NotNil(t, res.Cause)
+	assert.Equal(t, domain.ConnectionTimeout, *res.Cause)
+}
+
+func TestRabbitMQ_ConnectionFailed(t *testing.T) {
+	r := protoResource("127.0.0.1", 1, "rabbitmq")
+	res := rabbitmqCheck(context.Background(), r, "127.0.0.1", 1, false, 500*time.Millisecond, unsafeDialer)
+	assert.Equal(t, string(domain.StatusDown), res.Status)
+	require.NotNil(t, res.Cause)
+}
+
+func TestRabbitMQ_TLSNoise(t *testing.T) {
+	host, port := startMockTCP(t, func(conn net.Conn) {
+		hdr := make([]byte, 8)
+		io.ReadFull(conn, hdr)
+		// TLS ServerHello: 0x16 (Handshake) 0x03 0x03 (TLS 1.2), then 0x00 0x40 (length=64), then 64 garbage bytes
+		conn.Write([]byte{0x16, 0x03, 0x03, 0x00, 0x40})
+		conn.Write(bytes.Repeat([]byte{0xAA}, 64))
+	})
+	r := protoResource(host, port, "rabbitmq")
+	res := rabbitmqCheck(context.Background(), r, host, port, false, 1*time.Second, unsafeDialer)
+	assert.Equal(t, string(domain.StatusDown), res.Status)
+	require.NotNil(t, res.Cause)
+	assert.Equal(t, domain.ProtocolHandshakeFailed, *res.Cause)
+}

--- a/internal/service/resource_service.go
+++ b/internal/service/resource_service.go
@@ -136,7 +136,7 @@ func (s *ResourceService) CreateResource(ctx context.Context, payload *dto.Creat
 	}
 
 	if payload.Type == domain.ResourceProtocol {
-		if err := validateProtocolFields(payload.ProtocolType, payload.ProtocolPort); err != nil {
+		if err := validateProtocolFields(payload.ProtocolType, payload.ProtocolPort, payload.Target); err != nil {
 			return nil, err
 		}
 		resource.ProtocolType = payload.ProtocolType

--- a/internal/service/resource_update.go
+++ b/internal/service/resource_update.go
@@ -199,7 +199,7 @@ func applyAndValidateProtocol(resource *domain.Resource, payload *dto.UpdateReso
 	if payload.ProtocolPort != nil {
 		resource.ProtocolPort = payload.ProtocolPort
 	}
-	return validateProtocolFields(resource.ProtocolType, resource.ProtocolPort)
+	return validateProtocolFields(resource.ProtocolType, resource.ProtocolPort, resource.Target)
 }
 
 func (s *ResourceService) reconcileComponentChange(ctx context.Context, resource *domain.Resource, previousComponentID *string) {

--- a/internal/service/resource_validation.go
+++ b/internal/service/resource_validation.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"fmt"
+	"net"
+	"strings"
 
 	"github.com/denisakp/ogoune/internal/config"
 )
@@ -35,18 +37,66 @@ func validateKeywordFields(keyword *string, keywordMode *string) error {
 }
 
 // validateProtocolFields validates protocol-specific fields when resource type is protocol.
-func validateProtocolFields(protocolType *string, protocolPort *int) error {
+func validateProtocolFields(protocolType *string, protocolPort *int, target string) error {
 	if protocolType == nil || *protocolType == "" {
 		return fmt.Errorf("%w: protocol_type is required when resource type is 'protocol'", ErrValidationFailed)
 	}
-	validTypes := map[string]bool{"redis": true, "mongodb": true, "ftp": true, "ssh": true}
+	validTypes := map[string]bool{
+		"redis": true, "mongodb": true, "ftp": true, "ssh": true,
+		"mysql": true, "postgres": true,
+		"rabbitmq": true, "kafka": true,
+	}
 	if !validTypes[*protocolType] {
-		return fmt.Errorf("%w: protocol_type must be one of: redis, mongodb, ftp, ssh", ErrValidationFailed)
+		return fmt.Errorf("%w: protocol_type must be one of: redis, mongodb, ftp, ssh, mysql, postgres, rabbitmq, kafka", ErrValidationFailed)
+	}
+	if *protocolType == "kafka" {
+		if protocolPort != nil {
+			return fmt.Errorf("%w: protocol_port must be empty for kafka (encode ports in target as host:port,host:port)", ErrValidationFailed)
+		}
+		entries, err := parseKafkaBootstrapTargets(target)
+		if err != nil {
+			return fmt.Errorf("%w: %v", ErrValidationFailed, err)
+		}
+		if len(entries) == 0 {
+			return fmt.Errorf("%w: kafka requires at least one bootstrap host:port in target", ErrValidationFailed)
+		}
+	} else if *protocolType == "rabbitmq" {
+		if target == "" {
+			return fmt.Errorf("%w: target is required for rabbitmq", ErrValidationFailed)
+		}
+		if strings.Contains(target, ",") {
+			return fmt.Errorf("%w: rabbitmq target must be a single host (no commas)", ErrValidationFailed)
+		}
 	}
 	if protocolPort != nil && (*protocolPort < 1 || *protocolPort > 65535) {
 		return fmt.Errorf("%w: protocol_port must be between 1 and 65535", ErrValidationFailed)
 	}
 	return nil
+}
+
+// parseKafkaBootstrapTargets splits Target on comma, trims whitespace, validates each
+// entry as host:port via net.SplitHostPort. Returns the normalized list.
+func parseKafkaBootstrapTargets(target string) ([]string, error) {
+	if target == "" {
+		return nil, fmt.Errorf("target is empty")
+	}
+	parts := strings.Split(target, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		s := strings.TrimSpace(p)
+		if s == "" {
+			continue
+		}
+		host, port, err := net.SplitHostPort(s)
+		if err != nil {
+			return nil, fmt.Errorf("invalid bootstrap entry %q: %v", s, err)
+		}
+		if host == "" || port == "" {
+			return nil, fmt.Errorf("invalid bootstrap entry %q: host and port required", s)
+		}
+		out = append(out, net.JoinHostPort(host, port))
+	}
+	return out, nil
 }
 
 // validateSmartAlertingFields validates the smart alerting configuration fields.

--- a/internal/service/resource_validation_protocol_test.go
+++ b/internal/service/resource_validation_protocol_test.go
@@ -1,0 +1,53 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func intPtr(i int) *int { return &i }
+
+func TestValidateProtocolFields_AllValidTypes(t *testing.T) {
+	for _, pt := range []string{"redis", "mongodb", "ftp", "ssh", "mysql", "postgres", "rabbitmq"} {
+		err := validateProtocolFields(strPtr(pt), intPtr(1234), "broker.local")
+		require.NoError(t, err, "protocol %s should validate", pt)
+	}
+	// kafka requires bootstrap CSV in target and no protocol_port
+	err := validateProtocolFields(strPtr("kafka"), nil, "k1:9092,k2:9092")
+	require.NoError(t, err)
+}
+
+func TestValidateProtocolFields_RejectsUnknown(t *testing.T) {
+	err := validateProtocolFields(strPtr("amqp"), nil, "h:5672")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrValidationFailed))
+}
+
+func TestValidateProtocolFields_RabbitMQ_RejectsCommas(t *testing.T) {
+	err := validateProtocolFields(strPtr("rabbitmq"), nil, "h1,h2")
+	require.Error(t, err)
+}
+
+func TestValidateProtocolFields_Kafka_RejectsPort(t *testing.T) {
+	err := validateProtocolFields(strPtr("kafka"), intPtr(9092), "k1:9092")
+	require.Error(t, err)
+}
+
+func TestValidateProtocolFields_Kafka_RejectsEmptyBootstrap(t *testing.T) {
+	err := validateProtocolFields(strPtr("kafka"), nil, "")
+	require.Error(t, err)
+}
+
+func TestValidateProtocolFields_Kafka_RejectsMalformedEntry(t *testing.T) {
+	err := validateProtocolFields(strPtr("kafka"), nil, "k1:9092,nojustport")
+	require.Error(t, err)
+}
+
+func TestParseKafkaBootstrapTargets_Normalizes(t *testing.T) {
+	got, err := parseKafkaBootstrapTargets(" k1:9092 , k2:9092 ")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"k1:9092", "k2:9092"}, got)
+}

--- a/roadmap.md
+++ b/roadmap.md
@@ -130,7 +130,7 @@ Community Edition — reporting, tooling, and observability depth.
 
 - [x] **Protocol-aware checks — auth variants** — Redis AUTH, MySQL, PostgreSQL with encrypted credentials.
   Depends on credential encryption (AES-256-GCM) shipped in H2. Community Edition.
-- [ ] **Protocol-aware checks — broker support** — RabbitMQ (AMQP handshake), Kafka (Metadata Request).
+- [x] **Protocol-aware checks — broker support** — RabbitMQ (AMQP handshake), Kafka (Metadata Request).
   Community contribution candidates — architecture is extensible from H2.
 
 ### Reporting

--- a/roadmap.md
+++ b/roadmap.md
@@ -94,7 +94,7 @@ The CLA bot handles this automatically on your first PR.
 
 ---
 
-## H2 — SHipped
+## H2 — Shipped
 
 Community Edition — expanding monitoring coverage, observability, and security.
 
@@ -128,7 +128,7 @@ Community Edition — reporting, tooling, and observability depth.
 
 ### Monitoring
 
-- [ ] **Protocol-aware checks — auth variants** — Redis AUTH, MySQL, PostgreSQL with encrypted credentials.
+- [x] **Protocol-aware checks — auth variants** — Redis AUTH, MySQL, PostgreSQL with encrypted credentials.
   Depends on credential encryption (AES-256-GCM) shipped in H2. Community Edition.
 - [ ] **Protocol-aware checks — broker support** — RabbitMQ (AMQP handshake), Kafka (Metadata Request).
   Community contribution candidates — architecture is extensible from H2.
@@ -170,7 +170,6 @@ Community Edition — reporting, tooling, and observability depth.
 - [ ] **PagerDuty / OpsGenie**
 - [ ] **Cloud integrations** — Azure, Vercel, Cloudflare, Coolify
 - [ ] **Agent device monitoring** — CPU, memory, disk via lightweight Go agent
-- [ ] **Vault-backed credential encryption** — plug external secret managers (HashiCorp Vault, AWS KMS, Azure Key Vault, GCP Secret Manager) as the key provider. Replaces APP_SECRET_KEY with enterprise-grade key management. Depends on credential encryption (AES-256-GCM) shipped in H2.
 
 ---
 

--- a/web/src/components/resources/ResourceForm.vue
+++ b/web/src/components/resources/ResourceForm.vue
@@ -61,6 +61,8 @@ const protocolDefaultPorts: Record<string, number> = {
   ssh: 22,
   mysql: 3306,
   postgres: 5432,
+  rabbitmq: 5672,
+  kafka: 9092,
 }
 
 // Feature 028: credential state lives in the form. It is only persisted in
@@ -184,6 +186,18 @@ const handleSubmit = async () => {
     if (!form.value.protocol_type) return
     const port = form.value.protocol_port
     if (port !== undefined && (port < 1 || port > 65535)) return
+    if (form.value.protocol_type === 'kafka') {
+      const entries = (form.value.target ?? '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+      if (entries.length === 0) return
+      const hostPortRe = /^[A-Za-z0-9._-]+:\d{1,5}$/
+      if (entries.some((e) => !hostPortRe.test(e))) return
+    }
+    if (form.value.protocol_type === 'rabbitmq') {
+      if ((form.value.target ?? '').includes(',')) return
+    }
   }
   const thresholds = form.value.expiry_alert_thresholds?.trim()
   if (thresholds) {
@@ -397,6 +411,8 @@ const icmpWarning = computed(() => {
               <a-select-option value="ssh">SSH</a-select-option>
               <a-select-option value="mysql">MySQL</a-select-option>
               <a-select-option value="postgres">PostgreSQL</a-select-option>
+              <a-select-option value="rabbitmq">RabbitMQ</a-select-option>
+              <a-select-option value="kafka">Kafka (bootstrap brokers)</a-select-option>
             </a-select>
           </a-form-item>
         </a-col>

--- a/web/src/test/protocolValidation.spec.ts
+++ b/web/src/test/protocolValidation.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+
+// Mirrors the validation rules used by ResourceForm.vue handleSubmit for
+// protocol_type ∈ {rabbitmq, kafka}.
+const KAFKA_HOST_PORT_RE = /^[A-Za-z0-9._-]+:\d{1,5}$/
+
+function parseKafkaBootstrap(target: string): string[] {
+  return target.split(',').map((s) => s.trim()).filter(Boolean)
+}
+
+function kafkaTargetValid(target: string): boolean {
+  const entries = parseKafkaBootstrap(target)
+  if (entries.length === 0) return false
+  return entries.every((e) => KAFKA_HOST_PORT_RE.test(e))
+}
+
+function rabbitmqTargetValid(target: string): boolean {
+  if (!target?.trim()) return false
+  if (target.includes(',')) return false
+  return true
+}
+
+const DEFAULT_PORTS: Record<string, number> = {
+  redis: 6379, mongodb: 27017, ftp: 21, ssh: 22,
+  mysql: 3306, postgres: 5432, rabbitmq: 5672, kafka: 9092,
+}
+
+describe('protocol form validation', () => {
+  it('rabbitmq defaults port to 5672', () => {
+    expect(DEFAULT_PORTS.rabbitmq).toBe(5672)
+  })
+
+  it('kafka defaults port to 9092', () => {
+    expect(DEFAULT_PORTS.kafka).toBe(9092)
+  })
+
+  it('rejects empty rabbitmq target', () => {
+    expect(rabbitmqTargetValid('')).toBe(false)
+    expect(rabbitmqTargetValid('   ')).toBe(false)
+  })
+
+  it('rejects rabbitmq target with commas', () => {
+    expect(rabbitmqTargetValid('h1,h2')).toBe(false)
+  })
+
+  it('accepts rabbitmq single host', () => {
+    expect(rabbitmqTargetValid('rabbit.local')).toBe(true)
+  })
+
+  it('rejects empty kafka bootstrap list', () => {
+    expect(kafkaTargetValid('')).toBe(false)
+    expect(kafkaTargetValid(',,')).toBe(false)
+  })
+
+  it('rejects kafka entry without port', () => {
+    expect(kafkaTargetValid('host')).toBe(false)
+    expect(kafkaTargetValid('h1:9092,h2')).toBe(false)
+  })
+
+  it('accepts comma-separated kafka bootstrap and normalizes whitespace', () => {
+    const entries = parseKafkaBootstrap(' h1:9092 , h2:9092,h3:9092 ')
+    expect(entries).toEqual(['h1:9092', 'h2:9092', 'h3:9092'])
+    expect(kafkaTargetValid(' h1:9092 , h2:9092 ')).toBe(true)
+  })
+
+  it('rejects kafka port out of u16', () => {
+    expect(kafkaTargetValid('h1:999999')).toBe(false)
+  })
+})

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -55,7 +55,7 @@ export interface Resource {
   keyword?: string               // literal string to search for (max 500 chars)
   keyword_mode?: 'contains' | 'not_contains'
   // Protocol-specific fields (only present when type === 'protocol')
-  protocol_type?: 'redis' | 'mongodb' | 'ftp' | 'ssh' | 'mysql' | 'postgres'
+  protocol_type?: 'redis' | 'mongodb' | 'ftp' | 'ssh' | 'mysql' | 'postgres' | 'rabbitmq' | 'kafka'
   protocol_port?: number         // 1–65535; absent = use protocol default
 }
 
@@ -110,7 +110,7 @@ export interface CreateResource {
   keyword?: string
   keyword_mode?: 'contains' | 'not_contains'
   // Protocol-specific
-  protocol_type?: 'redis' | 'mongodb' | 'ftp' | 'ssh' | 'mysql' | 'postgres'
+  protocol_type?: 'redis' | 'mongodb' | 'ftp' | 'ssh' | 'mysql' | 'postgres' | 'rabbitmq' | 'kafka'
   protocol_port?: number         // 1–65535; absent = use protocol default
 }
 


### PR DESCRIPTION
This pull request introduces protocol-aware monitoring for RabbitMQ (AMQP 0-9-1) and Kafka brokers, expanding the system's ability to perform health checks on these services. It adds robust protocol handshake implementations, updates documentation, and includes comprehensive unit and integration tests to ensure reliability and correct error handling for various edge cases.

**Protocol Support Enhancements:**

* Added protocol handlers for `rabbitmq` (AMQP 0-9-1) and `kafka` to the `protocolHandlers` map in `protocol.go`, enabling first-class monitoring for these broker types.
* Implemented the `rabbitmqCheck` function in `protocol_rabbitmq.go`, which performs an AMQP 0-9-1 handshake and detects authentication requirements or protocol mismatches.
* Implemented the `kafkaCheck` function in `protocol_kafka.go`, which sends a Metadata Request v1 to each bootstrap broker, handles sequential failover, and validates broker responses, including error handling for authentication and protocol errors.

**Testing Improvements:**

* Added comprehensive unit tests for Kafka protocol handling in `protocol_kafka_test.go`, covering successful checks, error conditions, and edge cases.
* Added an integration test for Kafka in `protocol_kafka_integration_test.go` to verify real broker interaction.

**Documentation and Metadata Updates:**

* Updated the feature directory and references in `.specify/feature.json` and `CLAUDE.md` to point to the new broker protocol checks specification. [[1]](diffhunk://#diff-f5317a02f6ff349cdecbb91b03b28a062b4aafa952fd19df5b82083988e8c623L2-R2) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L193-R193)
* Expanded the `README.md` to document support for RabbitMQ and Kafka protocol-aware monitors, including details on handshake mechanisms and TLS detection.