### PR TITLE
feat: network toolbox (DNS/port/SSL/WHOIS) + Prometheus metrics page

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory":"specs/070-reports-dashboards"}
+{"feature_directory":"specs/071-toolbox-metrics"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,5 +196,5 @@ Dashboard: http://localhost:9009 (project `ogoune`). Block on CRITICAL/BLOCKER i
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/070-reports-dashboards/plan.md`
+`specs/071-toolbox-metrics/plan.md`
 <!-- SPECKIT END -->

--- a/internal/api/handler/v1/toolbox_handler.go
+++ b/internal/api/handler/v1/toolbox_handler.go
@@ -1,0 +1,250 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"time"
+
+	dtoV1 "github.com/denisakp/ogoune/internal/dto/v1"
+	"github.com/denisakp/ogoune/internal/service"
+)
+
+// ToolboxV1ServiceInterface is the slice of *service.ToolboxService used by the handler.
+type ToolboxV1ServiceInterface interface {
+	DNS(ctx context.Context, q service.ToolboxDNSQuery) (service.ToolboxDNSResult, error)
+	PortScan(ctx context.Context, q service.ToolboxPortScanQuery) (service.ToolboxPortScanResult, error)
+	SSL(ctx context.Context, q service.ToolboxSSLQuery) (service.ToolboxSSLResult, error)
+	WHOIS(ctx context.Context, domain string) (service.ToolboxWhoisResult, error)
+}
+
+// ToolboxHandler exposes the one-shot network tools under /api/v1/toolbox.
+type ToolboxHandler struct {
+	service ToolboxV1ServiceInterface
+}
+
+// NewToolboxHandler creates a new ToolboxHandler.
+func NewToolboxHandler(svc ToolboxV1ServiceInterface) *ToolboxHandler {
+	return &ToolboxHandler{service: svc}
+}
+
+// DNS handles POST /api/v1/toolbox/dns.
+//
+// @Summary  Run a one-off DNS lookup
+// @Tags     toolbox
+// @Security BearerAuth
+// @Accept   json
+// @Produce  json
+// @Param    body body dtoV1.DNSLookupRequest true "DNS lookup request"
+// @Success  200 {object} dtoV1.SingleResponse[dtoV1.DNSLookupResponse]
+// @Failure  400 {object} dtoV1.ErrorResponse
+// @Failure  403 {object} dtoV1.ErrorResponse
+// @Failure  429 {object} dtoV1.ErrorResponse
+// @Router   /toolbox/dns [post]
+func (h *ToolboxHandler) DNS(w http.ResponseWriter, r *http.Request) {
+	var req dtoV1.DNSLookupRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	res, err := h.service.DNS(r.Context(), service.ToolboxDNSQuery{
+		Domain:         req.Domain,
+		RecordTypes:    req.RecordTypes,
+		Resolver:       req.Resolver,
+		CustomResolver: req.CustomResolver,
+	})
+	if err != nil {
+		h.audit(r.Context(), "toolbox.dns", req.Domain, outcomeFromErr(err))
+		h.mapToolboxError(w, r, err)
+		return
+	}
+	records := make([]dtoV1.DNSRecord, 0, len(res.Records))
+	for _, rec := range res.Records {
+		records = append(records, dtoV1.DNSRecord{Type: rec.Type, Value: rec.Value, TTL: rec.TTL})
+	}
+	h.audit(r.Context(), "toolbox.dns", req.Domain, "ok")
+	respond(w, http.StatusOK, dtoV1.DNSLookupResponse{
+		Records:      records,
+		QueryMs:      res.QueryMs,
+		ResolverUsed: res.ResolverUsed,
+	})
+}
+
+// PortScan handles POST /api/v1/toolbox/port-scan.
+//
+// @Summary  Scan ports on a registered monitor host (rate-limited 5/min)
+// @Tags     toolbox
+// @Security BearerAuth
+// @Accept   json
+// @Produce  json
+// @Param    body body dtoV1.PortScanRequest true "Port scan request"
+// @Success  200 {object} dtoV1.SingleResponse[dtoV1.PortScanResponse]
+// @Failure  400 {object} dtoV1.ErrorResponse
+// @Failure  403 {object} dtoV1.ErrorResponse
+// @Failure  429 {object} dtoV1.ErrorResponse
+// @Router   /toolbox/port-scan [post]
+func (h *ToolboxHandler) PortScan(w http.ResponseWriter, r *http.Request) {
+	var req dtoV1.PortScanRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	res, err := h.service.PortScan(r.Context(), service.ToolboxPortScanQuery{
+		Target:    req.Target,
+		Ports:     req.Ports,
+		TimeoutMs: req.TimeoutMs,
+	})
+	if err != nil {
+		h.audit(r.Context(), "toolbox.port-scan", req.Target, outcomeFromErr(err))
+		h.mapToolboxError(w, r, err)
+		return
+	}
+	results := make([]dtoV1.PortResult, 0, len(res.Results))
+	for _, pr := range res.Results {
+		results = append(results, dtoV1.PortResult{Port: pr.Port, Service: pr.Service, Status: pr.Status, Banner: pr.Banner})
+	}
+	h.audit(r.Context(), "toolbox.port-scan", req.Target, "ok")
+	respond(w, http.StatusOK, dtoV1.PortScanResponse{
+		Results:      results,
+		OpenCount:    res.OpenCount,
+		ScannedCount: res.ScannedCount,
+	})
+}
+
+// SSL handles POST /api/v1/toolbox/ssl-check.
+//
+// @Summary  Inspect a TLS certificate
+// @Tags     toolbox
+// @Security BearerAuth
+// @Accept   json
+// @Produce  json
+// @Param    body body dtoV1.SSLCheckRequest true "SSL check request"
+// @Success  200 {object} dtoV1.SingleResponse[dtoV1.SSLCheckResponse]
+// @Failure  400 {object} dtoV1.ErrorResponse
+// @Failure  422 {object} dtoV1.ErrorResponse
+// @Router   /toolbox/ssl-check [post]
+func (h *ToolboxHandler) SSL(w http.ResponseWriter, r *http.Request) {
+	var req dtoV1.SSLCheckRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	res, err := h.service.SSL(r.Context(), service.ToolboxSSLQuery{Domain: req.Domain, Port: req.Port})
+	if err != nil {
+		h.audit(r.Context(), "toolbox.ssl-check", req.Domain, outcomeFromErr(err))
+		h.mapToolboxError(w, r, err)
+		return
+	}
+	vulns := make([]dtoV1.SSLVulnCheck, 0, len(res.Vulnerabilities))
+	for _, v := range res.Vulnerabilities {
+		vulns = append(vulns, dtoV1.SSLVulnCheck{Name: v.Name, Status: v.Status})
+	}
+	h.audit(r.Context(), "toolbox.ssl-check", req.Domain, "ok")
+	respond(w, http.StatusOK, dtoV1.SSLCheckResponse{
+		Certificate: dtoV1.SSLCertificate{
+			Subject:   res.Certificate.Subject,
+			Issuer:    res.Certificate.Issuer,
+			ValidFrom: res.Certificate.ValidFrom.UTC().Format(time.RFC3339),
+			ValidTo:   res.Certificate.ValidTo.UTC().Format(time.RFC3339),
+			Cipher:    res.Certificate.Cipher,
+			SANs:      res.Certificate.SANs,
+			Chain:     res.Certificate.Chain,
+		},
+		DaysToExpiry:    res.DaysToExpiry,
+		ExpiringSoon:    res.ExpiringSoon,
+		Vulnerabilities: vulns,
+	})
+}
+
+// WHOIS handles POST /api/v1/toolbox/whois.
+//
+// @Summary  Look up domain registration data
+// @Tags     toolbox
+// @Security BearerAuth
+// @Accept   json
+// @Produce  json
+// @Param    body body dtoV1.WhoisRequest true "WHOIS request"
+// @Success  200 {object} dtoV1.SingleResponse[dtoV1.WhoisResponse]
+// @Failure  400 {object} dtoV1.ErrorResponse
+// @Failure  422 {object} dtoV1.ErrorResponse
+// @Router   /toolbox/whois [post]
+func (h *ToolboxHandler) WHOIS(w http.ResponseWriter, r *http.Request) {
+	var req dtoV1.WhoisRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+	res, err := h.service.WHOIS(r.Context(), req.Domain)
+	if err != nil {
+		h.audit(r.Context(), "toolbox.whois", req.Domain, outcomeFromErr(err))
+		h.mapToolboxError(w, r, err)
+		return
+	}
+	h.audit(r.Context(), "toolbox.whois", req.Domain, "ok")
+	respond(w, http.StatusOK, dtoV1.WhoisResponse{
+		Registrar:    res.Registrar,
+		RegisteredAt: res.RegisteredAt,
+		UpdatedAt:    res.UpdatedAt,
+		ExpiresAt:    res.ExpiresAt,
+		DaysToExpiry: res.DaysToExpiry,
+		Status:       res.Status,
+		Privacy:      res.Privacy,
+		DNSSEC:       res.DNSSEC,
+		Nameservers:  res.Nameservers,
+	})
+}
+
+// decodeJSON decodes the request body, writing a 400 on failure.
+func decodeJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
+	if err := json.NewDecoder(r.Body).Decode(dst); err != nil {
+		respondError(w, r, http.StatusBadRequest, "VALIDATION_FAILED", "invalid JSON body")
+		return false
+	}
+	return true
+}
+
+// mapToolboxError maps a toolbox service error to an RFC-7807 response.
+func (h *ToolboxHandler) mapToolboxError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, service.ErrToolboxValidation):
+		respondError(w, r, http.StatusBadRequest, "VALIDATION_FAILED", err.Error())
+	case errors.Is(err, service.ErrToolboxTargetNotRegistered):
+		respondError(w, r, http.StatusForbidden, "TARGET_NOT_REGISTERED", "target must be a registered monitor host")
+	case errors.Is(err, service.ErrToolboxTargetBlocked):
+		respondError(w, r, http.StatusForbidden, "TARGET_BLOCKED", "target resolves to a blocked address")
+	case errors.Is(err, service.ErrToolboxCertUnavailable):
+		respondError(w, r, http.StatusUnprocessableEntity, "CERT_UNAVAILABLE", "certificate could not be retrieved")
+	case errors.Is(err, service.ErrToolboxWhoisNoData):
+		respondError(w, r, http.StatusUnprocessableEntity, "WHOIS_NO_DATA", "no registration data for domain")
+	default:
+		respondError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "toolbox request failed")
+	}
+}
+
+// outcomeFromErr maps an error to a stable audit outcome string.
+func outcomeFromErr(err error) string {
+	switch {
+	case errors.Is(err, service.ErrToolboxValidation):
+		return "validation_failed"
+	case errors.Is(err, service.ErrToolboxTargetNotRegistered):
+		return "refused_unregistered"
+	case errors.Is(err, service.ErrToolboxTargetBlocked):
+		return "blocked_ssrf"
+	case errors.Is(err, service.ErrToolboxCertUnavailable):
+		return "cert_unavailable"
+	case errors.Is(err, service.ErrToolboxWhoisNoData):
+		return "whois_no_data"
+	default:
+		return "error"
+	}
+}
+
+// audit emits a structured log entry for each toolbox run (FR-017). No table exists.
+func (h *ToolboxHandler) audit(ctx context.Context, action, target, outcome string) {
+	userID, _ := ctx.Value("user_id").(string)
+	slog.Default().LogAttrs(ctx, slog.LevelInfo, "audit",
+		slog.String("category", "toolbox"),
+		slog.String("action", action),
+		slog.String("user_id", userID),
+		slog.String("target", target),
+		slog.String("outcome", outcome),
+	)
+}

--- a/internal/api/handler/v1/toolbox_handler_test.go
+++ b/internal/api/handler/v1/toolbox_handler_test.go
@@ -1,0 +1,106 @@
+package v1
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/denisakp/ogoune/internal/service"
+)
+
+// stubToolboxService implements ToolboxV1ServiceInterface with canned outputs.
+type stubToolboxService struct {
+	dnsRes  service.ToolboxDNSResult
+	portRes service.ToolboxPortScanResult
+	sslRes  service.ToolboxSSLResult
+	whoRes  service.ToolboxWhoisResult
+	err     error
+}
+
+func (s *stubToolboxService) DNS(_ context.Context, _ service.ToolboxDNSQuery) (service.ToolboxDNSResult, error) {
+	return s.dnsRes, s.err
+}
+func (s *stubToolboxService) PortScan(_ context.Context, _ service.ToolboxPortScanQuery) (service.ToolboxPortScanResult, error) {
+	return s.portRes, s.err
+}
+func (s *stubToolboxService) SSL(_ context.Context, _ service.ToolboxSSLQuery) (service.ToolboxSSLResult, error) {
+	return s.sslRes, s.err
+}
+func (s *stubToolboxService) WHOIS(_ context.Context, _ string) (service.ToolboxWhoisResult, error) {
+	return s.whoRes, s.err
+}
+
+func doPost(h http.HandlerFunc, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h(rec, req)
+	return rec
+}
+
+func TestToolboxHandler_DNS_OK(t *testing.T) {
+	h := NewToolboxHandler(&stubToolboxService{dnsRes: service.ToolboxDNSResult{
+		Records:      []service.ToolboxDNSRecord{{Type: "A", Value: "93.184.216.34"}},
+		ResolverUsed: "1.1.1.1",
+	}})
+	rec := doPost(h.DNS, `{"domain":"example.com","record_types":["A"],"resolver":"cloudflare"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "93.184.216.34") {
+		t.Fatalf("missing record in body: %s", rec.Body.String())
+	}
+}
+
+func TestToolboxHandler_InvalidJSON(t *testing.T) {
+	h := NewToolboxHandler(&stubToolboxService{})
+	rec := doPost(h.DNS, `{not json`)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400", rec.Code)
+	}
+}
+
+func TestToolboxHandler_ErrorMapping(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    error
+		call   func(h *ToolboxHandler) http.HandlerFunc
+		body   string
+		status int
+		code   string
+	}{
+		{"dns validation", service.ErrToolboxValidation, func(h *ToolboxHandler) http.HandlerFunc { return h.DNS }, `{"domain":""}`, http.StatusBadRequest, "VALIDATION_FAILED"},
+		{"port not registered", service.ErrToolboxTargetNotRegistered, func(h *ToolboxHandler) http.HandlerFunc { return h.PortScan }, `{"target":"x","ports":[80]}`, http.StatusForbidden, "TARGET_NOT_REGISTERED"},
+		{"port blocked", service.ErrToolboxTargetBlocked, func(h *ToolboxHandler) http.HandlerFunc { return h.PortScan }, `{"target":"x","ports":[80]}`, http.StatusForbidden, "TARGET_BLOCKED"},
+		{"ssl cert unavailable", service.ErrToolboxCertUnavailable, func(h *ToolboxHandler) http.HandlerFunc { return h.SSL }, `{"domain":"x"}`, http.StatusUnprocessableEntity, "CERT_UNAVAILABLE"},
+		{"whois no data", service.ErrToolboxWhoisNoData, func(h *ToolboxHandler) http.HandlerFunc { return h.WHOIS }, `{"domain":"x"}`, http.StatusUnprocessableEntity, "WHOIS_NO_DATA"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewToolboxHandler(&stubToolboxService{err: tc.err})
+			rec := doPost(tc.call(h), tc.body)
+			if rec.Code != tc.status {
+				t.Fatalf("got %d, want %d; body=%s", rec.Code, tc.status, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), tc.code) {
+				t.Fatalf("body missing code %q: %s", tc.code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestToolboxHandler_PortScan_OK(t *testing.T) {
+	h := NewToolboxHandler(&stubToolboxService{portRes: service.ToolboxPortScanResult{
+		Results:      []service.ToolboxPortResult{{Port: 22, Service: "ssh", Status: "open"}},
+		OpenCount:    1,
+		ScannedCount: 1,
+	}})
+	rec := doPost(h.PortScan, `{"target":"db-01","ports":[22],"timeout_ms":500}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"open_count":1`) {
+		t.Fatalf("missing open_count: %s", rec.Body.String())
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -60,6 +60,7 @@ func NewRouter(
 	statusPageV1Handler *v1handler.StatusPageV1Handler,
 	heartbeatV1Handler *v1handler.HeartbeatV1Handler,
 	credentialV1Handler *v1handler.ResourceCredentialHandler,
+	toolboxV1Handler *v1handler.ToolboxHandler,
 	enableSwagger bool,
 	cfg *config.Config,
 ) http.Handler {
@@ -341,6 +342,14 @@ func NewRouter(
 			// Status page routes — registered in T034
 			r.Route("/status-pages", func(r chi.Router) {
 				r.Get("/", statusPageV1Handler.List)
+			})
+			// Toolbox — one-shot network tools (spec 071). Write-scoped + per-user
+			// rate-limited; port-scan strictest (5/min), others 20/min.
+			r.Route("/toolbox", func(r chi.Router) {
+				r.With(middleware.RequireReadWrite, middleware.PerUserRateLimit(20)).Post("/dns", toolboxV1Handler.DNS)
+				r.With(middleware.RequireReadWrite, middleware.PerUserRateLimit(5)).Post("/port-scan", toolboxV1Handler.PortScan)
+				r.With(middleware.RequireReadWrite, middleware.PerUserRateLimit(20)).Post("/ssl-check", toolboxV1Handler.SSL)
+				r.With(middleware.RequireReadWrite, middleware.PerUserRateLimit(20)).Post("/whois", toolboxV1Handler.WHOIS)
 			})
 		})
 	})

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -80,6 +80,7 @@ func TestNewRouter_PingIsPublicAndResourcesAreProtected(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		false,
 		&config.Config{
 			RateLimitAuth:         10,

--- a/internal/dto/v1/toolbox.go
+++ b/internal/dto/v1/toolbox.go
@@ -1,0 +1,120 @@
+package v1
+
+// Toolbox request/response DTOs for the one-shot network tools exposed under
+// /api/v1/toolbox/{dns,port-scan,ssl-check,whois}. See specs/071-toolbox-metrics.
+
+// --- DNS Lookup ---------------------------------------------------------------
+
+// DNSLookupRequest is the body of POST /api/v1/toolbox/dns.
+// @name DNSLookupRequest
+type DNSLookupRequest struct {
+	Domain         string   `json:"domain"`
+	RecordTypes    []string `json:"record_types"`
+	Resolver       string   `json:"resolver"`
+	CustomResolver string   `json:"custom_resolver,omitempty"`
+}
+
+// DNSRecord is a single resolved DNS record.
+// Note: TTL is not exposed by the Go standard-library resolver; it is reported
+// as 0 until a DNS library with TTL support is adopted (follow-up).
+// @name DNSRecord
+type DNSRecord struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+	TTL   int    `json:"ttl"`
+}
+
+// DNSLookupResponse is the result of a DNS lookup.
+// @name DNSLookupResponse
+type DNSLookupResponse struct {
+	Records      []DNSRecord `json:"records"`
+	QueryMs      int64       `json:"query_ms"`
+	ResolverUsed string      `json:"resolver_used"`
+}
+
+// --- Port Scanner -------------------------------------------------------------
+
+// PortScanRequest is the body of POST /api/v1/toolbox/port-scan.
+// @name PortScanRequest
+type PortScanRequest struct {
+	Target    string `json:"target"`
+	Ports     []int  `json:"ports"`
+	Preset    string `json:"preset,omitempty"`
+	TimeoutMs int    `json:"timeout_ms"`
+}
+
+// PortResult is the scan outcome for one port.
+// @name PortResult
+type PortResult struct {
+	Port    int    `json:"port"`
+	Service string `json:"service"`
+	Status  string `json:"status"` // open | closed | filtered
+	Banner  string `json:"banner,omitempty"`
+}
+
+// PortScanResponse is the result of a port scan.
+// @name PortScanResponse
+type PortScanResponse struct {
+	Results      []PortResult `json:"results"`
+	OpenCount    int          `json:"open_count"`
+	ScannedCount int          `json:"scanned_count"`
+}
+
+// --- SSL Checker --------------------------------------------------------------
+
+// SSLCheckRequest is the body of POST /api/v1/toolbox/ssl-check.
+// @name SSLCheckRequest
+type SSLCheckRequest struct {
+	Domain string `json:"domain"`
+	Port   int    `json:"port,omitempty"`
+}
+
+// SSLCertificate holds the inspected certificate fields.
+// @name SSLCertificate
+type SSLCertificate struct {
+	Subject   string   `json:"subject"`
+	Issuer    string   `json:"issuer"`
+	ValidFrom string   `json:"valid_from"`
+	ValidTo   string   `json:"valid_to"`
+	Cipher    string   `json:"cipher"`
+	SANs      []string `json:"sans"`
+	Chain     []string `json:"chain"`
+}
+
+// SSLVulnCheck is a single passive vulnerability indicator.
+// @name SSLVulnCheck
+type SSLVulnCheck struct {
+	Name   string `json:"name"`
+	Status string `json:"status"` // pass | warn
+}
+
+// SSLCheckResponse is the result of an SSL check.
+// @name SSLCheckResponse
+type SSLCheckResponse struct {
+	Certificate     SSLCertificate `json:"certificate"`
+	DaysToExpiry    int            `json:"days_to_expiry"`
+	ExpiringSoon    bool           `json:"expiring_soon"`
+	Vulnerabilities []SSLVulnCheck `json:"vulnerabilities"`
+}
+
+// --- WHOIS --------------------------------------------------------------------
+
+// WhoisRequest is the body of POST /api/v1/toolbox/whois.
+// @name WhoisRequest
+type WhoisRequest struct {
+	Domain string `json:"domain"`
+}
+
+// WhoisResponse is the result of a WHOIS lookup.
+// @name WhoisResponse
+type WhoisResponse struct {
+	Registrar    string   `json:"registrar"`
+	RegisteredAt string   `json:"registered_at"`
+	UpdatedAt    string   `json:"updated_at"`
+	ExpiresAt    string   `json:"expires_at"`
+	DaysToExpiry int      `json:"days_to_expiry"`
+	Status       []string `json:"status"`
+	Privacy      bool     `json:"privacy"`
+	DNSSEC       bool     `json:"dnssec"`
+	Nameservers  []string `json:"nameservers"`
+}

--- a/internal/platform/bootstrap/router.go
+++ b/internal/platform/bootstrap/router.go
@@ -82,13 +82,16 @@ func InitRouter(app *App) {
 	credentialTester := service.NewResourceCredentialTester(app.ResourceRepo, BuildStrategies())
 	credentialV1Handler := v1handler.NewResourceCredentialHandler(credentialService, credentialTester)
 
+	toolboxService := service.NewToolboxService(app.ResourceRepo, 10*time.Second)
+	toolboxV1Handler := v1handler.NewToolboxHandler(toolboxService)
+
 	// Set APP_VERSION env
 	err := os.Setenv("APP_VERSION", AppVersion)
 	if err != nil {
 		return
 	}
 
-	apiHandler := api.NewRouter(resourceHandler, pingHandler, activityHandler, tagHandler, componentHandler, statusPageHandler, publicStatusHandler, asCacheRecorder(app.PublicStatusCacheMetr), statusPageSettingsHandler, incidentHandler, incidentUpdateHandler, notificationHandler, maintenanceHandler, statsHandler, systemHandler, runtimeConfigHandler, authHandler, accountHandler, app.AuthService, app.APIKeyService, app.SessionService, sessionHandler, twoFactorV1Handler, escalationV1Handler, monitorV1Handler, incidentV1Handler, channelV1Handler, componentV1Handler, tagV1Handler, statusPageV1Handler, heartbeatV1Handler, credentialV1Handler, cfg.EnableSwagger, cfg)
+	apiHandler := api.NewRouter(resourceHandler, pingHandler, activityHandler, tagHandler, componentHandler, statusPageHandler, publicStatusHandler, asCacheRecorder(app.PublicStatusCacheMetr), statusPageSettingsHandler, incidentHandler, incidentUpdateHandler, notificationHandler, maintenanceHandler, statsHandler, systemHandler, runtimeConfigHandler, authHandler, accountHandler, app.AuthService, app.APIKeyService, app.SessionService, sessionHandler, twoFactorV1Handler, escalationV1Handler, monitorV1Handler, incidentV1Handler, channelV1Handler, componentV1Handler, tagV1Handler, statusPageV1Handler, heartbeatV1Handler, credentialV1Handler, toolboxV1Handler, cfg.EnableSwagger, cfg)
 
 	// Root router
 	rootRouter := chi.NewRouter()

--- a/internal/service/toolbox_service.go
+++ b/internal/service/toolbox_service.go
@@ -1,0 +1,563 @@
+package service
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/denisakp/ogoune/internal/port"
+	"github.com/denisakp/ogoune/pkg/safenet"
+	"github.com/likexian/whois"
+	whoisparser "github.com/likexian/whois-parser"
+)
+
+// Toolbox domain-level errors. Handlers map these to HTTP status codes.
+var (
+	ErrToolboxValidation          = errors.New("toolbox: invalid request")
+	ErrToolboxTargetBlocked       = errors.New("toolbox: target blocked (internal/private address)")
+	ErrToolboxTargetNotRegistered = errors.New("toolbox: target is not a registered monitor")
+	ErrToolboxCertUnavailable     = errors.New("toolbox: certificate could not be retrieved")
+	ErrToolboxWhoisNoData         = errors.New("toolbox: no registration data for domain")
+)
+
+// Toolbox tuning constants (clarified 2026-06-27).
+const (
+	toolboxMaxPorts          = 100
+	toolboxMinPortTimeoutMs  = 100
+	toolboxMaxPortTimeoutMs  = 2000
+	toolboxDefTimeoutMs      = 1000
+	toolboxSSLExpiryWarnDays = 14
+	toolboxResourceScanLimit = 1000
+)
+
+// dnsResolvers maps a friendly resolver name to its IP.
+var dnsResolvers = map[string]string{
+	"cloudflare": "1.1.1.1",
+	"google":     "8.8.8.8",
+	"quad9":      "9.9.9.9",
+}
+
+// allowedDNSRecordTypes is the set of supported record types.
+var allowedDNSRecordTypes = map[string]bool{
+	"A": true, "AAAA": true, "MX": true, "NS": true, "TXT": true, "CNAME": true,
+}
+
+// wellKnownPorts maps common ports to a service label for port-scan results.
+var wellKnownPorts = map[int]string{
+	21: "ftp", 22: "ssh", 23: "telnet", 25: "smtp", 53: "dns", 80: "http",
+	110: "pop3", 143: "imap", 443: "https", 465: "smtps", 587: "smtp",
+	993: "imaps", 995: "pop3s", 3306: "mysql", 3389: "rdp", 5432: "postgres",
+	6379: "redis", 8080: "http-alt", 8443: "https-alt", 27017: "mongodb",
+}
+
+// --- Service-level result types (decoupled from DTOs) ------------------------
+
+type ToolboxDNSRecord struct {
+	Type  string
+	Value string
+	TTL   int
+}
+
+type ToolboxDNSResult struct {
+	Records      []ToolboxDNSRecord
+	QueryMs      int64
+	ResolverUsed string
+}
+
+type ToolboxPortResult struct {
+	Port    int
+	Service string
+	Status  string
+	Banner  string
+}
+
+type ToolboxPortScanResult struct {
+	Results      []ToolboxPortResult
+	OpenCount    int
+	ScannedCount int
+}
+
+type ToolboxSSLCertificate struct {
+	Subject   string
+	Issuer    string
+	ValidFrom time.Time
+	ValidTo   time.Time
+	Cipher    string
+	SANs      []string
+	Chain     []string
+}
+
+type ToolboxSSLVuln struct {
+	Name   string
+	Status string // pass | warn
+}
+
+type ToolboxSSLResult struct {
+	Certificate     ToolboxSSLCertificate
+	DaysToExpiry    int
+	ExpiringSoon    bool
+	Vulnerabilities []ToolboxSSLVuln
+}
+
+type ToolboxWhoisResult struct {
+	Registrar    string
+	RegisteredAt string
+	UpdatedAt    string
+	ExpiresAt    string
+	DaysToExpiry int
+	Status       []string
+	Privacy      bool
+	DNSSEC       bool
+	Nameservers  []string
+}
+
+// --- Request types -----------------------------------------------------------
+
+type ToolboxDNSQuery struct {
+	Domain         string
+	RecordTypes    []string
+	Resolver       string
+	CustomResolver string
+}
+
+type ToolboxPortScanQuery struct {
+	Target    string
+	Ports     []int
+	TimeoutMs int
+}
+
+type ToolboxSSLQuery struct {
+	Domain string
+	Port   int
+}
+
+// --- Service -----------------------------------------------------------------
+
+// ToolboxService runs one-shot network diagnostics (DNS/port/SSL/WHOIS).
+// It performs no persistence; the only repository access is a read-only lookup
+// of registered monitor targets to gate the port scanner (FR-016).
+type ToolboxService struct {
+	resourceRepo port.ResourceRepository
+	timeout      time.Duration
+	clock        func() time.Time
+}
+
+// NewToolboxService builds a ToolboxService. timeout bounds external calls.
+func NewToolboxService(repo port.ResourceRepository, timeout time.Duration) *ToolboxService {
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return &ToolboxService{resourceRepo: repo, timeout: timeout, clock: time.Now}
+}
+
+// DNS performs a DNS lookup for the requested record types via the chosen resolver.
+func (s *ToolboxService) DNS(ctx context.Context, q ToolboxDNSQuery) (ToolboxDNSResult, error) {
+	var res ToolboxDNSResult
+
+	domain := strings.TrimSpace(q.Domain)
+	if domain == "" {
+		return res, fmt.Errorf("%w: domain is required", ErrToolboxValidation)
+	}
+	types := q.RecordTypes
+	if len(types) == 0 {
+		types = []string{"A"}
+	}
+	for _, t := range types {
+		if !allowedDNSRecordTypes[strings.ToUpper(t)] {
+			return res, fmt.Errorf("%w: unsupported record type %q", ErrToolboxValidation, t)
+		}
+	}
+
+	resolver, resolverIP, err := s.buildResolver(q.Resolver, q.CustomResolver)
+	if err != nil {
+		return res, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+
+	start := s.clock()
+	records := make([]ToolboxDNSRecord, 0)
+	for _, raw := range types {
+		t := strings.ToUpper(raw)
+		recs, lookupErr := s.lookupRecordType(ctx, resolver, t, domain)
+		if lookupErr != nil {
+			// Per-type "no records" is not a hard error; skip silently.
+			continue
+		}
+		records = append(records, recs...)
+	}
+	res.Records = records
+	res.QueryMs = time.Since(start).Milliseconds()
+	res.ResolverUsed = resolverIP
+	return res, nil
+}
+
+func (s *ToolboxService) buildResolver(name, custom string) (*net.Resolver, string, error) {
+	name = strings.ToLower(strings.TrimSpace(name))
+	var ip string
+	switch name {
+	case "", "cloudflare":
+		ip = dnsResolvers["cloudflare"]
+	case "google", "quad9":
+		ip = dnsResolvers[name]
+	case "custom":
+		host := strings.TrimSpace(custom)
+		if h, _, err := net.SplitHostPort(host); err == nil {
+			host = h
+		}
+		parsed := net.ParseIP(host)
+		if parsed == nil {
+			return nil, "", fmt.Errorf("%w: custom_resolver must be a valid IP", ErrToolboxValidation)
+		}
+		if safenet.IsBlockedIP(parsed) {
+			return nil, "", fmt.Errorf("%w: custom resolver", ErrToolboxTargetBlocked)
+		}
+		ip = host
+	default:
+		return nil, "", fmt.Errorf("%w: unknown resolver %q", ErrToolboxValidation, name)
+	}
+
+	addr := net.JoinHostPort(ip, "53")
+	r := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			d := net.Dialer{}
+			return d.DialContext(ctx, "udp", addr)
+		},
+	}
+	return r, ip, nil
+}
+
+func (s *ToolboxService) lookupRecordType(ctx context.Context, r *net.Resolver, t, domain string) ([]ToolboxDNSRecord, error) {
+	switch t {
+	case "A", "AAAA":
+		network := "ip4"
+		if t == "AAAA" {
+			network = "ip6"
+		}
+		ips, err := r.LookupIP(ctx, network, domain)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]ToolboxDNSRecord, 0, len(ips))
+		for _, ip := range ips {
+			out = append(out, ToolboxDNSRecord{Type: t, Value: ip.String()})
+		}
+		return out, nil
+	case "MX":
+		mxs, err := r.LookupMX(ctx, domain)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]ToolboxDNSRecord, 0, len(mxs))
+		for _, mx := range mxs {
+			out = append(out, ToolboxDNSRecord{Type: t, Value: fmt.Sprintf("%d %s", mx.Pref, mx.Host)})
+		}
+		return out, nil
+	case "NS":
+		nss, err := r.LookupNS(ctx, domain)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]ToolboxDNSRecord, 0, len(nss))
+		for _, ns := range nss {
+			out = append(out, ToolboxDNSRecord{Type: t, Value: ns.Host})
+		}
+		return out, nil
+	case "TXT":
+		txts, err := r.LookupTXT(ctx, domain)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]ToolboxDNSRecord, 0, len(txts))
+		for _, txt := range txts {
+			out = append(out, ToolboxDNSRecord{Type: t, Value: txt})
+		}
+		return out, nil
+	case "CNAME":
+		cname, err := r.LookupCNAME(ctx, domain)
+		if err != nil {
+			return nil, err
+		}
+		return []ToolboxDNSRecord{{Type: t, Value: cname}}, nil
+	default:
+		return nil, fmt.Errorf("%w: unsupported record type", ErrToolboxValidation)
+	}
+}
+
+// PortScan scans the requested ports on a target that MUST be a registered monitor host.
+func (s *ToolboxService) PortScan(ctx context.Context, q ToolboxPortScanQuery) (ToolboxPortScanResult, error) {
+	var res ToolboxPortScanResult
+
+	target := normalizeHostname(strings.TrimSpace(q.Target))
+	if target == "" {
+		return res, fmt.Errorf("%w: target is required", ErrToolboxValidation)
+	}
+	if len(q.Ports) == 0 {
+		return res, fmt.Errorf("%w: at least one port is required", ErrToolboxValidation)
+	}
+	if len(q.Ports) > toolboxMaxPorts {
+		return res, fmt.Errorf("%w: at most %d ports per scan", ErrToolboxValidation, toolboxMaxPorts)
+	}
+	for _, p := range q.Ports {
+		if p < 1 || p > 65535 {
+			return res, fmt.Errorf("%w: port %d out of range 1-65535", ErrToolboxValidation, p)
+		}
+	}
+	timeoutMs := q.TimeoutMs
+	if timeoutMs == 0 {
+		timeoutMs = toolboxDefTimeoutMs
+	}
+	if timeoutMs < toolboxMinPortTimeoutMs || timeoutMs > toolboxMaxPortTimeoutMs {
+		return res, fmt.Errorf("%w: timeout_ms must be between %d and %d", ErrToolboxValidation, toolboxMinPortTimeoutMs, toolboxMaxPortTimeoutMs)
+	}
+
+	// FR-016: gate to registered monitor targets.
+	registered, err := s.isRegisteredTarget(ctx, target)
+	if err != nil {
+		return res, err
+	}
+	if !registered {
+		return res, ErrToolboxTargetNotRegistered
+	}
+
+	perPort := time.Duration(timeoutMs) * time.Millisecond
+	results := make([]ToolboxPortResult, 0, len(q.Ports))
+	for _, p := range q.Ports {
+		results = append(results, s.scanPort(ctx, target, p, perPort))
+	}
+	res.Results = results
+	res.ScannedCount = len(results)
+	for _, r := range results {
+		if r.Status == "open" {
+			res.OpenCount++
+		}
+	}
+	return res, nil
+}
+
+func (s *ToolboxService) scanPort(ctx context.Context, host string, p int, timeout time.Duration) ToolboxPortResult {
+	out := ToolboxPortResult{Port: p, Service: wellKnownPorts[p], Status: "closed"}
+	dialCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	conn, err := safenet.SafeDial(dialCtx, "tcp", net.JoinHostPort(host, fmt.Sprintf("%d", p)))
+	if err != nil {
+		if strings.Contains(err.Error(), "blocked") {
+			out.Status = "filtered"
+			return out
+		}
+		if errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "timeout") || strings.Contains(err.Error(), "i/o timeout") {
+			out.Status = "filtered"
+		}
+		return out
+	}
+	defer conn.Close()
+	out.Status = "open"
+
+	// Best-effort short banner read.
+	_ = conn.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	buf := make([]byte, 256)
+	if n, rerr := conn.Read(buf); rerr == nil && n > 0 {
+		out.Banner = strings.TrimSpace(string(buf[:n]))
+	}
+	return out
+}
+
+// SSL inspects the TLS certificate of domain:port and derives expiry + passive vuln indicators.
+func (s *ToolboxService) SSL(ctx context.Context, q ToolboxSSLQuery) (ToolboxSSLResult, error) {
+	var res ToolboxSSLResult
+
+	domain := normalizeHostname(strings.TrimSpace(q.Domain))
+	if domain == "" {
+		return res, fmt.Errorf("%w: domain is required", ErrToolboxValidation)
+	}
+	port := q.Port
+	if port == 0 {
+		port = 443
+	}
+	if port < 1 || port > 65535 {
+		return res, fmt.Errorf("%w: port out of range 1-65535", ErrToolboxValidation)
+	}
+
+	if err := safenet.ValidateResolvedIPs(domain); err != nil {
+		return res, fmt.Errorf("%w: %v", ErrToolboxTargetBlocked, err)
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, s.timeout)
+	defer cancel()
+
+	td := &tls.Dialer{
+		NetDialer: &net.Dialer{},
+		Config: &tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // inspection tool: we report on the cert, not trust it
+			ServerName:         domain,
+		},
+	}
+	nc, err := td.DialContext(dialCtx, "tcp", net.JoinHostPort(domain, fmt.Sprintf("%d", port)))
+	if err != nil {
+		return res, fmt.Errorf("%w: %v", ErrToolboxCertUnavailable, err)
+	}
+	defer nc.Close()
+	tlsConn, ok := nc.(*tls.Conn)
+	if !ok {
+		return res, ErrToolboxCertUnavailable
+	}
+
+	state := tlsConn.ConnectionState()
+	if len(state.PeerCertificates) == 0 {
+		return res, ErrToolboxCertUnavailable
+	}
+	leaf := state.PeerCertificates[0]
+
+	chain := make([]string, 0, len(state.PeerCertificates))
+	for _, c := range state.PeerCertificates {
+		chain = append(chain, c.Subject.CommonName)
+	}
+
+	res.Certificate = ToolboxSSLCertificate{
+		Subject:   leaf.Subject.String(),
+		Issuer:    issuerName(leaf),
+		ValidFrom: leaf.NotBefore,
+		ValidTo:   leaf.NotAfter,
+		Cipher:    tls.CipherSuiteName(state.CipherSuite),
+		SANs:      leaf.DNSNames,
+		Chain:     chain,
+	}
+	res.DaysToExpiry = int(time.Until(leaf.NotAfter).Hours() / 24)
+	res.ExpiringSoon = res.DaysToExpiry < toolboxSSLExpiryWarnDays
+	res.Vulnerabilities = assessTLSVulnerabilities(state.Version, state.CipherSuite)
+	return res, nil
+}
+
+// WHOIS looks up domain registration data.
+func (s *ToolboxService) WHOIS(ctx context.Context, domain string) (ToolboxWhoisResult, error) {
+	var res ToolboxWhoisResult
+	domain = normalizeHostname(strings.TrimSpace(domain))
+	if domain == "" {
+		return res, fmt.Errorf("%w: domain is required", ErrToolboxValidation)
+	}
+
+	raw, err := whois.Whois(domain)
+	if err != nil {
+		return res, fmt.Errorf("%w: %v", ErrToolboxWhoisNoData, err)
+	}
+	info, err := whoisparser.Parse(raw)
+	if err != nil {
+		return res, fmt.Errorf("%w: %v", ErrToolboxWhoisNoData, err)
+	}
+	if info.Domain == nil {
+		return res, ErrToolboxWhoisNoData
+	}
+
+	res.Status = info.Domain.Status
+	res.Nameservers = info.Domain.NameServers
+	res.DNSSEC = info.Domain.DNSSec
+	res.RegisteredAt = info.Domain.CreatedDate
+	res.UpdatedAt = info.Domain.UpdatedDate
+	res.ExpiresAt = info.Domain.ExpirationDate
+	if info.Registrar != nil {
+		res.Registrar = info.Registrar.Name
+	}
+	if info.Registrant != nil && info.Registrant.Name != "" {
+		res.Privacy = strings.Contains(strings.ToLower(info.Registrant.Name), "privacy") ||
+			strings.Contains(strings.ToLower(info.Registrant.Organization), "privacy")
+	}
+	if info.Domain.ExpirationDateInTime != nil {
+		res.DaysToExpiry = int(time.Until(*info.Domain.ExpirationDateInTime).Hours() / 24)
+	}
+	return res, nil
+}
+
+// isRegisteredTarget reports whether host matches the hostname of any existing
+// monitor target. Read-only; no migration / sqlc (FR-016).
+func (s *ToolboxService) isRegisteredTarget(ctx context.Context, host string) (bool, error) {
+	resources, err := s.resourceRepo.List(ctx, toolboxResourceScanLimit, 0)
+	if err != nil {
+		return false, err
+	}
+	want := strings.ToLower(host)
+	for _, r := range resources {
+		if r == nil {
+			continue
+		}
+		if strings.ToLower(normalizeHostname(r.Target)) == want {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// normalizeHostname extracts a bare hostname from a URL, host:port, or bare host.
+// Mirrors EnrichmentService.extractHostname.
+func normalizeHostname(target string) string {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return ""
+	}
+	if u, err := url.Parse(target); err == nil && u.Host != "" {
+		host := u.Host
+		if h, _, err := net.SplitHostPort(host); err == nil {
+			return h
+		}
+		return host
+	}
+	if host, _, err := net.SplitHostPort(target); err == nil {
+		return host
+	}
+	return target
+}
+
+// issuerName returns the certificate issuer organization, falling back to CN.
+func issuerName(cert *x509.Certificate) string {
+	if len(cert.Issuer.Organization) > 0 {
+		return cert.Issuer.Organization[0]
+	}
+	return cert.Issuer.CommonName
+}
+
+// assessTLSVulnerabilities derives passive pass/warn indicators from the negotiated
+// TLS version and cipher (no active exploit probing — clarified 2026-06-27).
+func assessTLSVulnerabilities(version uint16, cipher uint16) []ToolboxSSLVuln {
+	// POODLE: SSLv3. BEAST: TLS 1.0 with CBC. Heartbleed: OpenSSL bug — not
+	// detectable passively; reported pass unless an obviously legacy stack.
+	modernTLS := version >= tls.VersionTLS12
+	weakCipher := isWeakCipher(cipher)
+
+	poodle := "pass"
+	if version <= tls.VersionSSL30 { //nolint:staticcheck // intentional legacy check
+		poodle = "warn"
+	}
+	beast := "pass"
+	if version <= tls.VersionTLS10 {
+		beast = "warn"
+	}
+	heartbleed := "pass" // not passively detectable; conservative pass
+	weak := "pass"
+	if weakCipher || !modernTLS {
+		weak = "warn"
+	}
+	return []ToolboxSSLVuln{
+		{Name: "Heartbleed", Status: heartbleed},
+		{Name: "POODLE", Status: poodle},
+		{Name: "BEAST", Status: beast},
+		{Name: "WeakCipher", Status: weak},
+	}
+}
+
+// isWeakCipher flags cipher suites Go marks insecure (RC4, 3DES, CBC-SHA legacy).
+func isWeakCipher(id uint16) bool {
+	for _, c := range tls.InsecureCipherSuites() {
+		if c.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/service/toolbox_service_test.go
+++ b/internal/service/toolbox_service_test.go
@@ -1,0 +1,128 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/denisakp/ogoune/internal/domain"
+	"github.com/denisakp/ogoune/internal/repository/fake"
+	"github.com/denisakp/ogoune/internal/service"
+)
+
+func newToolboxSvc(t *testing.T, targets ...string) *service.ToolboxService {
+	t.Helper()
+	repo := fake.NewResourceFake()
+	for i, tg := range targets {
+		_, err := repo.Create(context.Background(), &domain.Resource{
+			Name:   "r" + string(rune('a'+i)),
+			Type:   domain.ResourceTCP,
+			Target: tg,
+		})
+		if err != nil {
+			t.Fatalf("seed resource: %v", err)
+		}
+	}
+	return service.NewToolboxService(repo, 3*time.Second)
+}
+
+func TestToolboxDNS_Validation(t *testing.T) {
+	svc := newToolboxSvc(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		q    service.ToolboxDNSQuery
+		want error
+	}{
+		{"empty domain", service.ToolboxDNSQuery{Domain: ""}, service.ErrToolboxValidation},
+		{"bad record type", service.ToolboxDNSQuery{Domain: "example.com", RecordTypes: []string{"WAT"}}, service.ErrToolboxValidation},
+		{"unknown resolver", service.ToolboxDNSQuery{Domain: "example.com", Resolver: "nope"}, service.ErrToolboxValidation},
+		{"custom resolver not ip", service.ToolboxDNSQuery{Domain: "example.com", Resolver: "custom", CustomResolver: "not-an-ip"}, service.ErrToolboxValidation},
+		{"custom resolver private", service.ToolboxDNSQuery{Domain: "example.com", Resolver: "custom", CustomResolver: "10.0.0.1"}, service.ErrToolboxTargetBlocked},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.DNS(ctx, tc.q)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("got %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestToolboxPortScan_Validation(t *testing.T) {
+	svc := newToolboxSvc(t)
+	ctx := context.Background()
+
+	tooMany := make([]int, 101)
+	for i := range tooMany {
+		tooMany[i] = i + 1
+	}
+
+	cases := []struct {
+		name string
+		q    service.ToolboxPortScanQuery
+	}{
+		{"empty target", service.ToolboxPortScanQuery{Ports: []int{80}}},
+		{"no ports", service.ToolboxPortScanQuery{Target: "example.com"}},
+		{"too many ports", service.ToolboxPortScanQuery{Target: "example.com", Ports: tooMany}},
+		{"port out of range", service.ToolboxPortScanQuery{Target: "example.com", Ports: []int{70000}}},
+		{"timeout too low", service.ToolboxPortScanQuery{Target: "example.com", Ports: []int{80}, TimeoutMs: 10}},
+		{"timeout too high", service.ToolboxPortScanQuery{Target: "example.com", Ports: []int{80}, TimeoutMs: 9000}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.PortScan(ctx, tc.q)
+			if !errors.Is(err, service.ErrToolboxValidation) {
+				t.Fatalf("got %v, want validation error", err)
+			}
+		})
+	}
+}
+
+func TestToolboxPortScan_TargetGating(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("unregistered refused before dial", func(t *testing.T) {
+		svc := newToolboxSvc(t, "https://known.example.com")
+		_, err := svc.PortScan(ctx, service.ToolboxPortScanQuery{
+			Target: "unknown.example.org", Ports: []int{80}, TimeoutMs: 500,
+		})
+		if !errors.Is(err, service.ErrToolboxTargetNotRegistered) {
+			t.Fatalf("got %v, want ErrToolboxTargetNotRegistered", err)
+		}
+	})
+
+	t.Run("registered host matched via URL target normalization", func(t *testing.T) {
+		// Seed a monitor whose Target is a full URL; the scanner must match by hostname.
+		svc := newToolboxSvc(t, "https://known.example.com/health")
+		_, err := svc.PortScan(ctx, service.ToolboxPortScanQuery{
+			Target: "known.example.com", Ports: []int{1}, TimeoutMs: 100,
+		})
+		// Must NOT be refused as unregistered (it may fail to connect — that's fine).
+		if errors.Is(err, service.ErrToolboxTargetNotRegistered) {
+			t.Fatalf("registered host was wrongly refused: %v", err)
+		}
+	})
+}
+
+func TestToolboxSSL_Validation(t *testing.T) {
+	svc := newToolboxSvc(t)
+	ctx := context.Background()
+
+	if _, err := svc.SSL(ctx, service.ToolboxSSLQuery{Domain: ""}); !errors.Is(err, service.ErrToolboxValidation) {
+		t.Fatalf("empty domain: got %v", err)
+	}
+	if _, err := svc.SSL(ctx, service.ToolboxSSLQuery{Domain: "example.com", Port: 70000}); !errors.Is(err, service.ErrToolboxValidation) {
+		t.Fatalf("bad port: got %v", err)
+	}
+}
+
+func TestToolboxWHOIS_Validation(t *testing.T) {
+	svc := newToolboxSvc(t)
+	if _, err := svc.WHOIS(context.Background(), "  "); !errors.Is(err, service.ErrToolboxValidation) {
+		t.Fatalf("empty domain: got %v", err)
+	}
+}

--- a/web/src/components/layout/AppSidebar.vue
+++ b/web/src/components/layout/AppSidebar.vue
@@ -24,6 +24,11 @@ const report: NavItem[] = [
   { label: 'Dashboards', to: '/dashboards', icon: 'i-lucide-layout-grid' },
 ]
 
+const tools: NavItem[] = [
+  { label: 'Toolbox', to: '/toolbox', icon: 'i-lucide-wrench' },
+  { label: 'Metrics', to: '/metrics', icon: 'i-lucide-line-chart' },
+]
+
 const settings: NavItem[] = [
   { label: 'Notifications', to: '/notifications', icon: 'i-lucide-bell' },
   { label: 'Escalation', to: '/escalation', icon: 'i-lucide-siren' },
@@ -75,6 +80,21 @@ function linkClass(to: string): string {
         <div class="space-y-1">
           <RouterLink
             v-for="item in report"
+            :key="item.to"
+            :to="item.to"
+            class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors"
+            :class="linkClass(item.to)"
+          >
+            <UIcon :name="item.icon" class="size-4" />
+            <span>{{ item.label }}</span>
+          </RouterLink>
+        </div>
+      </section>
+      <section>
+        <div class="px-2 py-1 text-xs font-medium text-muted uppercase tracking-wide">Tools</div>
+        <div class="space-y-1">
+          <RouterLink
+            v-for="item in tools"
             :key="item.to"
             :to="item.to"
             class="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm transition-colors"

--- a/web/src/components/resources/ResourceForm.vue
+++ b/web/src/components/resources/ResourceForm.vue
@@ -15,9 +15,12 @@ import type { Resource, Tag } from '@/types'
 
 interface Props {
   resource?: Resource | null
+  // Seed for "create from toolbox" (spec 071) — pre-fills type/target/name on a
+  // NEW monitor without entering edit mode.
+  initial?: { type?: string; target?: string; name?: string } | null
 }
 
-const props = withDefaults(defineProps<Props>(), { resource: null })
+const props = withDefaults(defineProps<Props>(), { resource: null, initial: null })
 const emit = defineEmits<{ submit: []; cancel: [] }>()
 
 const formRef = ref<{
@@ -117,7 +120,7 @@ function initialState(): FormState {
       ...targetToPerType(String(r.type), r.target as string | undefined),
     } as FormState
   }
-  return {
+  const base: FormState = {
     type: 'http',
     name: '',
     interval: 60,
@@ -129,12 +132,22 @@ function initialState(): FormState {
     tags: [],
     notification_channels: [],
   }
+  if (props.initial) {
+    const seedType = props.initial.type || 'http'
+    return {
+      ...base,
+      type: seedType as ResourceInput['type'],
+      name: props.initial.name ?? base.name,
+      ...targetToPerType(seedType, props.initial.target),
+    } as FormState
+  }
+  return base
 }
 
 const state = reactive<FormState>(initialState())
 
 watch(
-  () => props.resource,
+  () => [props.resource, props.initial],
   () => {
     Object.assign(state, initialState())
   },

--- a/web/src/components/resources/ResourceModal.vue
+++ b/web/src/components/resources/ResourceModal.vue
@@ -7,11 +7,13 @@ import ResourceForm from './ResourceForm.vue'
 interface Props {
   open?: boolean
   resource?: Resource | null
+  initial?: { type?: string; target?: string; name?: string } | null
 }
 
 const props = withDefaults(defineProps<Props>(), {
   open: false,
   resource: null,
+  initial: null,
 })
 
 const emit = defineEmits<{
@@ -41,7 +43,12 @@ function onFormCancel() {
 <template>
   <UModal v-model:open="isOpen" :title="modalTitle" :ui="{ content: 'sm:max-w-xl' }">
     <template #body>
-      <ResourceForm :resource="resource" @submit="onFormSubmit" @cancel="onFormCancel" />
+      <ResourceForm
+        :resource="resource"
+        :initial="initial"
+        @submit="onFormSubmit"
+        @cancel="onFormCancel"
+      />
     </template>
   </UModal>
 </template>

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -28,6 +28,12 @@ const MaintenanceView = () => import('@/views/maintenance/MaintenanceListView.vu
 const ReportsView = () => import('@/views/reports/ReportsView.vue')
 const DashboardsView = () => import('@/views/dashboards/DashboardsView.vue')
 const DashboardDetailView = () => import('@/views/dashboards/DashboardDetailView.vue')
+const ToolboxLayoutView = () => import('@/views/toolbox/ToolboxLayoutView.vue')
+const DnsToolView = () => import('@/views/toolbox/DnsToolView.vue')
+const PortToolView = () => import('@/views/toolbox/PortToolView.vue')
+const SslToolView = () => import('@/views/toolbox/SslToolView.vue')
+const WhoisToolView = () => import('@/views/toolbox/WhoisToolView.vue')
+const MetricsView = () => import('@/views/metrics/MetricsView.vue')
 const Error404View = () => import('@/views/errors/Error404View.vue')
 const Error500View = () => import('@/views/errors/Error500View.vue')
 const MaintenanceModeView = () => import('@/views/errors/MaintenanceModeView.vue')
@@ -243,6 +249,26 @@ const routes: RouteRecordRaw[] = [
     name: 'MaintenanceMode',
     component: MaintenanceModeView,
     meta: { public: true, requiresLayout: false },
+  },
+
+  // Spec 071 — Toolbox (route-synced tabs) + Metrics doc page.
+  {
+    path: '/toolbox',
+    component: ToolboxLayoutView,
+    meta: { requiresAuth: true, requiresLayout: true, breadcrumbLabel: 'Toolbox' },
+    redirect: '/toolbox/dns',
+    children: [
+      { path: 'dns', name: 'ToolboxDns', component: DnsToolView, meta: { requiresAuth: true } },
+      { path: 'port', name: 'ToolboxPort', component: PortToolView, meta: { requiresAuth: true } },
+      { path: 'ssl', name: 'ToolboxSsl', component: SslToolView, meta: { requiresAuth: true } },
+      { path: 'whois', name: 'ToolboxWhois', component: WhoisToolView, meta: { requiresAuth: true } },
+    ],
+  },
+  {
+    path: '/metrics',
+    name: 'Metrics',
+    component: MetricsView,
+    meta: { requiresAuth: true, requiresLayout: true, breadcrumbLabel: 'Metrics' },
   },
 ]
 

--- a/web/src/schemas/toolbox-dns.schema.spec.ts
+++ b/web/src/schemas/toolbox-dns.schema.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { dnsLookupSchema } from '@/schemas/toolbox-dns.schema'
+
+describe('dnsLookupSchema', () => {
+  it('accepts a valid lookup', () => {
+    const r = dnsLookupSchema.safeParse({
+      domain: 'example.com',
+      record_types: ['A', 'MX'],
+      resolver: 'cloudflare',
+    })
+    expect(r.success).toBe(true)
+  })
+
+  it('rejects an empty domain', () => {
+    const r = dnsLookupSchema.safeParse({ domain: '', record_types: ['A'], resolver: 'google' })
+    expect(r.success).toBe(false)
+  })
+
+  it('rejects an invalid domain', () => {
+    const r = dnsLookupSchema.safeParse({ domain: 'not a domain', record_types: ['A'], resolver: 'google' })
+    expect(r.success).toBe(false)
+  })
+
+  it('requires at least one record type', () => {
+    const r = dnsLookupSchema.safeParse({ domain: 'example.com', record_types: [], resolver: 'google' })
+    expect(r.success).toBe(false)
+  })
+
+  it('requires custom_resolver when resolver is custom', () => {
+    const r = dnsLookupSchema.safeParse({
+      domain: 'example.com',
+      record_types: ['A'],
+      resolver: 'custom',
+    })
+    expect(r.success).toBe(false)
+  })
+
+  it('accepts custom resolver with an IP', () => {
+    const r = dnsLookupSchema.safeParse({
+      domain: 'example.com',
+      record_types: ['A'],
+      resolver: 'custom',
+      custom_resolver: '192.0.2.1',
+    })
+    expect(r.success).toBe(true)
+  })
+})

--- a/web/src/schemas/toolbox-dns.schema.ts
+++ b/web/src/schemas/toolbox-dns.schema.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+// DNS lookup form schema (spec 071, US1).
+
+export const dnsRecordTypes = ['A', 'AAAA', 'MX', 'NS', 'TXT', 'CNAME'] as const
+export const dnsResolvers = ['cloudflare', 'google', 'quad9', 'custom'] as const
+
+// Hostname (RFC-1123-ish): labels of letters/digits/hyphens separated by dots.
+const hostname = z
+  .string()
+  .trim()
+  .min(1, 'Required')
+  .regex(/^(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$/, 'Enter a valid domain')
+
+export const dnsLookupSchema = z
+  .object({
+    domain: hostname,
+    record_types: z.array(z.enum(dnsRecordTypes)).min(1, 'Pick at least one record type'),
+    resolver: z.enum(dnsResolvers),
+    custom_resolver: z.string().trim().optional(),
+  })
+  .refine(
+    (v) => v.resolver !== 'custom' || (v.custom_resolver?.length ?? 0) > 0,
+    { message: 'Custom resolver IP is required', path: ['custom_resolver'] },
+  )
+
+export type DnsLookupInput = z.infer<typeof dnsLookupSchema>

--- a/web/src/schemas/toolbox-port.schema.spec.ts
+++ b/web/src/schemas/toolbox-port.schema.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { portScanSchema, portPresetValues } from '@/schemas/toolbox-port.schema'
+
+describe('portScanSchema', () => {
+  it('accepts a valid scan', () => {
+    const r = portScanSchema.safeParse({ target: 'db-01', preset: 'common', ports: [22, 80], timeout_ms: 1000 })
+    expect(r.success).toBe(true)
+  })
+  it('rejects > 100 ports', () => {
+    const ports = Array.from({ length: 101 }, (_, i) => i + 1)
+    expect(portScanSchema.safeParse({ target: 'h', preset: 'custom', ports, timeout_ms: 500 }).success).toBe(false)
+  })
+  it('rejects an out-of-range port', () => {
+    expect(portScanSchema.safeParse({ target: 'h', preset: 'custom', ports: [70000], timeout_ms: 500 }).success).toBe(false)
+  })
+  it('rejects timeout outside 100–2000', () => {
+    expect(portScanSchema.safeParse({ target: 'h', preset: 'common', ports: [80], timeout_ms: 50 }).success).toBe(false)
+    expect(portScanSchema.safeParse({ target: 'h', preset: 'common', ports: [80], timeout_ms: 9000 }).success).toBe(false)
+  })
+  it('exposes preset port lists', () => {
+    expect(portPresetValues.web).toContain(443)
+  })
+})

--- a/web/src/schemas/toolbox-port.schema.ts
+++ b/web/src/schemas/toolbox-port.schema.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod'
+
+// Port scanner form schema (spec 071, US3). Mirrors backend caps:
+// max 100 ports, timeout 100–2000ms (default 1000).
+
+export const portPresets = ['common', 'web', 'db', 'custom'] as const
+
+export const portPresetValues: Record<(typeof portPresets)[number], number[]> = {
+  common: [21, 22, 25, 53, 80, 110, 143, 443, 3306, 5432],
+  web: [80, 443, 8080, 8443],
+  db: [3306, 5432, 6379, 27017, 1521, 1433],
+  custom: [],
+}
+
+const target = z
+  .string()
+  .trim()
+  .min(1, 'Required')
+  .regex(/^(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$/, 'Enter a valid host')
+
+export const portScanSchema = z.object({
+  target,
+  preset: z.enum(portPresets),
+  ports: z
+    .array(z.number().int().min(1, '1–65535').max(65535, '1–65535'))
+    .min(1, 'At least one port')
+    .max(100, 'At most 100 ports per scan'),
+  timeout_ms: z.number().int().min(100, 'Min 100ms').max(2000, 'Max 2000ms'),
+})
+
+export type PortScanInput = z.infer<typeof portScanSchema>

--- a/web/src/schemas/toolbox-ssl.schema.spec.ts
+++ b/web/src/schemas/toolbox-ssl.schema.spec.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { sslCheckSchema } from '@/schemas/toolbox-ssl.schema'
+
+describe('sslCheckSchema', () => {
+  it('accepts a valid domain + port', () => {
+    expect(sslCheckSchema.safeParse({ domain: 'example.com', port: 443 }).success).toBe(true)
+  })
+  it('rejects an invalid domain', () => {
+    expect(sslCheckSchema.safeParse({ domain: 'bad domain', port: 443 }).success).toBe(false)
+  })
+  it('rejects an out-of-range port', () => {
+    expect(sslCheckSchema.safeParse({ domain: 'example.com', port: 70000 }).success).toBe(false)
+  })
+})

--- a/web/src/schemas/toolbox-ssl.schema.ts
+++ b/web/src/schemas/toolbox-ssl.schema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+
+// SSL checker form schema (spec 071, US2).
+
+const domain = z
+  .string()
+  .trim()
+  .min(1, 'Required')
+  .regex(/^(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$/, 'Enter a valid domain')
+
+export const sslCheckSchema = z.object({
+  domain,
+  port: z.number().int().min(1, '1–65535').max(65535, '1–65535'),
+})
+
+export type SslCheckInput = z.infer<typeof sslCheckSchema>

--- a/web/src/schemas/toolbox-whois.schema.spec.ts
+++ b/web/src/schemas/toolbox-whois.schema.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+import { whoisSchema } from '@/schemas/toolbox-whois.schema'
+
+describe('whoisSchema', () => {
+  it('accepts a valid domain', () => {
+    expect(whoisSchema.safeParse({ domain: 'example.com' }).success).toBe(true)
+  })
+  it('rejects an empty domain', () => {
+    expect(whoisSchema.safeParse({ domain: '' }).success).toBe(false)
+  })
+})

--- a/web/src/schemas/toolbox-whois.schema.ts
+++ b/web/src/schemas/toolbox-whois.schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+
+// WHOIS form schema (spec 071, US4).
+
+const domain = z
+  .string()
+  .trim()
+  .min(1, 'Required')
+  .regex(/^(?!-)[A-Za-z0-9-]{1,63}(?<!-)(\.(?!-)[A-Za-z0-9-]{1,63}(?<!-))*$/, 'Enter a valid domain')
+
+export const whoisSchema = z.object({ domain })
+
+export type WhoisInput = z.infer<typeof whoisSchema>

--- a/web/src/services/toolboxService.spec.ts
+++ b/web/src/services/toolboxService.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { http, HttpResponse } from 'msw'
+
+import { dnsLookup, sslCheck, whoisLookup } from '@/services/toolboxService'
+import { ForbiddenError } from '@/core/errors'
+import { server } from '@/test/msw/server'
+
+describe('toolboxService', () => {
+  it('dnsLookup POSTs and unwraps the v1 envelope', async () => {
+    let body: unknown
+    server.use(
+      http.post('*/v1/toolbox/dns', async ({ request }) => {
+        body = await request.json()
+        return HttpResponse.json({
+          data: { records: [{ type: 'A', value: '1.2.3.4', ttl: 0 }], query_ms: 12, resolver_used: '1.1.1.1' },
+        })
+      }),
+    )
+
+    const res = await dnsLookup({ domain: 'example.com', record_types: ['A'], resolver: 'cloudflare' })
+    expect(res.records[0]?.value).toBe('1.2.3.4')
+    expect(res.resolver_used).toBe('1.1.1.1')
+    expect(body).toMatchObject({ domain: 'example.com', resolver: 'cloudflare' })
+  })
+
+  it('sslCheck unwraps expiring_soon', async () => {
+    server.use(
+      http.post('*/v1/toolbox/ssl-check', () =>
+        HttpResponse.json({
+          data: {
+            certificate: { subject: 'CN=x', issuer: 'i', valid_from: '', valid_to: '', cipher: '', sans: [], chain: [] },
+            days_to_expiry: 5,
+            expiring_soon: true,
+            vulnerabilities: [],
+          },
+        }),
+      ),
+    )
+    const res = await sslCheck({ domain: 'example.com' })
+    expect(res.expiring_soon).toBe(true)
+    expect(res.days_to_expiry).toBe(5)
+  })
+
+  it('maps a 403 to ForbiddenError', async () => {
+    server.use(
+      http.post('*/v1/toolbox/whois', () =>
+        HttpResponse.json({ error: { code: 'WHOIS_NO_DATA', message: 'no data' } }, { status: 403 }),
+      ),
+    )
+    await expect(whoisLookup({ domain: 'example.com' })).rejects.toBeInstanceOf(ForbiddenError)
+  })
+})

--- a/web/src/services/toolboxService.ts
+++ b/web/src/services/toolboxService.ts
@@ -1,0 +1,67 @@
+import { getAuthenticatedClient, request } from '@/core/http/client'
+import type {
+  DnsLookupRequest,
+  DnsLookupResponse,
+  PortScanRequest,
+  PortScanResponse,
+  SslCheckRequest,
+  SslCheckResponse,
+  WhoisRequest,
+  WhoisResponse,
+} from '@/types/toolbox'
+
+// v1 endpoints wrap payloads in a { data } envelope; unwrap it here.
+interface V1Envelope<T> {
+  data: T
+}
+
+// Toolbox one-shot network tools (spec 071). Each call accepts an optional
+// AbortSignal so the UI can cancel slow external lookups.
+
+export const dnsLookup = async (
+  payload: DnsLookupRequest,
+  signal?: AbortSignal,
+): Promise<DnsLookupResponse> => {
+  const envelope = await request<V1Envelope<DnsLookupResponse>>(
+    getAuthenticatedClient(),
+    'v1/toolbox/dns',
+    { method: 'POST', json: payload, signal },
+  )
+  return envelope.data
+}
+
+export const portScan = async (
+  payload: PortScanRequest,
+  signal?: AbortSignal,
+): Promise<PortScanResponse> => {
+  const envelope = await request<V1Envelope<PortScanResponse>>(
+    getAuthenticatedClient(),
+    'v1/toolbox/port-scan',
+    { method: 'POST', json: payload, signal },
+  )
+  return envelope.data
+}
+
+export const sslCheck = async (
+  payload: SslCheckRequest,
+  signal?: AbortSignal,
+): Promise<SslCheckResponse> => {
+  const envelope = await request<V1Envelope<SslCheckResponse>>(
+    getAuthenticatedClient(),
+    'v1/toolbox/ssl-check',
+    { method: 'POST', json: payload, signal },
+  )
+  return envelope.data
+}
+
+export const whoisLookup = async (
+  payload: WhoisRequest,
+  signal?: AbortSignal,
+): Promise<WhoisResponse> => {
+  const envelope = await request<V1Envelope<WhoisResponse>>(
+    getAuthenticatedClient(),
+    'v1/toolbox/whois',
+    { method: 'POST', json: payload, signal },
+  )
+  return envelope.data
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -881,3 +881,25 @@ export type {
   DashboardHealthStatus,
   DashboardHealth,
 } from './dashboards'
+
+// ─── Spec 071: Toolbox + Metrics ────────────────────────────────────────────
+
+export type {
+  DnsRecordType,
+  DnsResolver,
+  DnsLookupRequest,
+  DnsRecord,
+  DnsLookupResponse,
+  PortPreset,
+  PortStatus,
+  PortScanRequest,
+  PortResult,
+  PortScanResponse,
+  SslCertificate,
+  SslVulnCheck,
+  SslCheckRequest,
+  SslCheckResponse,
+  WhoisRequest,
+  WhoisResponse,
+  DnsHistoryEntry,
+} from './toolbox'

--- a/web/src/types/toolbox.ts
+++ b/web/src/types/toolbox.ts
@@ -1,0 +1,100 @@
+// Toolbox network-tool request/result types — mirrors internal/dto/v1/toolbox.go.
+// Spec 071.
+
+// --- DNS ---
+export type DnsRecordType = 'A' | 'AAAA' | 'MX' | 'NS' | 'TXT' | 'CNAME'
+export type DnsResolver = 'cloudflare' | 'google' | 'quad9' | 'custom'
+
+export interface DnsLookupRequest {
+  domain: string
+  record_types: DnsRecordType[]
+  resolver: DnsResolver
+  custom_resolver?: string
+}
+
+export interface DnsRecord {
+  type: string
+  value: string
+  ttl: number
+}
+
+export interface DnsLookupResponse {
+  records: DnsRecord[]
+  query_ms: number
+  resolver_used: string
+}
+
+// --- Port scan ---
+export type PortPreset = 'common' | 'web' | 'db' | 'custom'
+export type PortStatus = 'open' | 'closed' | 'filtered'
+
+export interface PortScanRequest {
+  target: string
+  ports: number[]
+  preset?: PortPreset
+  timeout_ms: number
+}
+
+export interface PortResult {
+  port: number
+  service: string
+  status: PortStatus
+  banner?: string
+}
+
+export interface PortScanResponse {
+  results: PortResult[]
+  open_count: number
+  scanned_count: number
+}
+
+// --- SSL ---
+export interface SslCertificate {
+  subject: string
+  issuer: string
+  valid_from: string
+  valid_to: string
+  cipher: string
+  sans: string[]
+  chain: string[]
+}
+
+export interface SslVulnCheck {
+  name: string
+  status: 'pass' | 'warn'
+}
+
+export interface SslCheckRequest {
+  domain: string
+  port?: number
+}
+
+export interface SslCheckResponse {
+  certificate: SslCertificate
+  days_to_expiry: number
+  expiring_soon: boolean
+  vulnerabilities: SslVulnCheck[]
+}
+
+// --- WHOIS ---
+export interface WhoisRequest {
+  domain: string
+}
+
+export interface WhoisResponse {
+  registrar: string
+  registered_at: string
+  updated_at: string
+  expires_at: string
+  days_to_expiry: number
+  status: string[]
+  privacy: boolean
+  dnssec: boolean
+  nameservers: string[]
+}
+
+// --- Client-side DNS lookup history (session-scoped) ---
+export interface DnsHistoryEntry {
+  request: DnsLookupRequest
+  at: number
+}

--- a/web/src/views/metrics/MetricsView.vue
+++ b/web/src/views/metrics/MetricsView.vue
@@ -1,0 +1,158 @@
+<script setup lang="ts">
+/**
+ * Prometheus Metrics documentation page (spec 071, US5).
+ * Static reference for the existing GET /metrics endpoint — no live stats
+ * (out of scope, FR-022). Describes endpoint, auth, catalog, scrape config.
+ */
+import { computed, ref } from 'vue'
+import { useToast } from '@nuxt/ui/composables/useToast'
+
+const toast = useToast()
+
+// Derive the endpoint from the API base URL (strip a trailing /api segment).
+const endpointUrl = computed(() => {
+  const base = (import.meta.env.VITE_API_BASE_URL as string) || '/api'
+  const origin = typeof window !== 'undefined' ? window.location.origin : ''
+  const root = base.replace(/\/api\/?$/, '').replace(/\/$/, '')
+  const prefix = root.startsWith('http') ? root : `${origin}${root}`
+  return `${prefix}/metrics`
+})
+
+const tokenRevealed = ref(false)
+
+const catalog = [
+  { name: 'ogoune_resource_up', type: 'gauge', description: 'Whether the resource is currently up (1=up, 0=down).' },
+  { name: 'ogoune_resource_status', type: 'gauge', description: 'Current status (0=unknown,1=up,2=down,3=paused).' },
+  { name: 'ogoune_incidents_total', type: 'counter', description: 'All-time total incidents for the resource.' },
+  { name: 'ogoune_incidents_active', type: 'gauge', description: 'Currently open incidents for the resource.' },
+  { name: 'ogoune_uptime_ratio', type: 'gauge', description: 'Uptime ratio (0.0–1.0) over a time window.' },
+]
+
+const scrapeConfig = computed(
+  () => `scrape_configs:
+  - job_name: ogoune
+    metrics_path: /metrics
+    authorization:
+      type: Bearer
+      credentials: <METRICS_TOKEN>
+    static_configs:
+      - targets: ['${endpointUrl.value.replace(/^https?:\/\//, '')}']`,
+)
+
+const curlExample = computed(
+  () => `$ curl -H "Authorization: Bearer $METRICS_TOKEN" ${endpointUrl.value}
+
+# HELP ogoune_resource_up Whether the resource is currently up (1=up, 0=down).
+# TYPE ogoune_resource_up gauge
+ogoune_resource_up{resource_id="01H...",name="api"} 1
+# TYPE ogoune_uptime_ratio gauge
+ogoune_uptime_ratio{resource_id="01H...",window="24h"} 0.998`,
+)
+
+function typeColor(type: string): 'primary' | 'warning' | 'success' {
+  if (type === 'counter') return 'warning'
+  if (type === 'histogram') return 'success'
+  return 'primary'
+}
+
+async function copy(value: string, label = 'Copied') {
+  try {
+    await navigator.clipboard.writeText(value)
+    toast.add({ title: label, color: 'success' })
+  } catch {
+    toast.add({ title: 'Copy failed', color: 'error' })
+  }
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-6 w-full min-h-full bg-default text-default">
+    <header class="flex flex-col gap-1">
+      <h1 class="text-2xl font-bold text-highlighted">Prometheus Metrics</h1>
+      <p class="text-sm text-muted">Scrape Ogoune metrics into your monitoring stack.</p>
+    </header>
+
+    <div class="flex flex-col lg:flex-row gap-6">
+      <div class="flex-1 min-w-0 flex flex-col gap-6">
+        <!-- Hero -->
+        <div class="rounded-lg border border-default p-4 flex flex-col gap-3">
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-medium text-highlighted">Endpoint</span>
+            <UBadge color="success" variant="subtle" size="sm">Enabled via ENABLE_METRICS</UBadge>
+          </div>
+          <div class="flex items-center gap-2">
+            <code class="flex-1 px-3 py-2 rounded-md bg-elevated font-mono text-sm break-all">{{ endpointUrl }}</code>
+            <UButton icon="i-lucide-copy" color="neutral" variant="subtle" size="sm" @click="copy(endpointUrl)" />
+          </div>
+          <div class="flex items-center gap-2 text-sm">
+            <span class="text-muted">Bearer token</span>
+            <code class="font-mono">{{ tokenRevealed ? '$METRICS_TOKEN' : '••••••••' }}</code>
+            <UButton
+              :icon="tokenRevealed ? 'i-lucide-eye-off' : 'i-lucide-eye'"
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              @click="tokenRevealed = !tokenRevealed"
+            />
+            <span class="text-xs text-muted">(set server-side via METRICS_TOKEN)</span>
+          </div>
+        </div>
+
+        <!-- Catalog -->
+        <div class="rounded-lg border border-default overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead class="bg-elevated text-muted">
+              <tr>
+                <th class="text-left font-medium px-3 py-2">Metric</th>
+                <th class="text-left font-medium px-3 py-2">Type</th>
+                <th class="text-left font-medium px-3 py-2">Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="m in catalog" :key="m.name" class="border-t border-default">
+                <td class="px-3 py-2 font-mono">{{ m.name }}</td>
+                <td class="px-3 py-2">
+                  <UBadge :color="typeColor(m.type)" variant="subtle" size="sm">{{ m.type }}</UBadge>
+                </td>
+                <td class="px-3 py-2 text-muted">{{ m.description }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Curl sandbox -->
+        <div class="rounded-lg border border-default overflow-hidden">
+          <div class="flex items-center justify-between px-3 py-2 bg-elevated">
+            <span class="text-xs font-medium text-muted uppercase tracking-wide">Example</span>
+            <UButton icon="i-lucide-copy" color="neutral" variant="ghost" size="xs" @click="copy(curlExample)" />
+          </div>
+          <pre class="px-3 py-3 bg-gray-950 text-green-400 text-xs font-mono overflow-x-auto">{{ curlExample }}</pre>
+        </div>
+      </div>
+
+      <!-- Right sidebar -->
+      <div class="w-full lg:w-80 shrink-0 flex flex-col gap-6">
+        <div class="rounded-lg border border-default overflow-hidden">
+          <div class="flex items-center justify-between px-3 py-2 bg-elevated">
+            <span class="text-xs font-medium text-muted uppercase tracking-wide">Scrape config</span>
+            <UButton icon="i-lucide-copy" color="neutral" variant="ghost" size="xs" @click="copy(scrapeConfig, 'Config copied')" />
+          </div>
+          <pre class="px-3 py-3 text-xs font-mono overflow-x-auto">{{ scrapeConfig }}</pre>
+        </div>
+
+        <div class="rounded-lg border border-default p-4 flex flex-col gap-2 text-sm">
+          <div class="font-medium text-highlighted">Integrations</div>
+          <div class="flex items-center justify-between">
+            <span>Grafana</span><UButton size="xs" variant="subtle" color="neutral">Import dashboard</UButton>
+          </div>
+          <div class="flex items-center justify-between">
+            <span>Alertmanager</span><UButton size="xs" variant="subtle" color="neutral">Examples</UButton>
+          </div>
+          <div class="flex items-center justify-between text-muted">
+            <span>OpenTelemetry</span><UBadge color="neutral" variant="subtle" size="sm">Soon</UBadge>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/src/views/metrics/__tests__/MetricsView.spec.ts
+++ b/web/src/views/metrics/__tests__/MetricsView.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('@nuxt/ui/composables/useToast', () => ({ useToast: () => ({ add: vi.fn() }) }))
+import MetricsView from '../MetricsView.vue'
+
+const stubs = {
+  UButton: { template: '<button><slot /></button>' },
+  UBadge: { template: '<span><slot /></span>' },
+}
+
+describe('MetricsView', () => {
+  it('renders the endpoint, catalog, and integrations', () => {
+    const w = mount(MetricsView, { global: { stubs } })
+    expect(w.text()).toContain('/metrics')
+    expect(w.text()).toContain('ogoune_resource_up')
+    expect(w.text()).toContain('Grafana')
+  })
+})

--- a/web/src/views/resources/ResourcesView.vue
+++ b/web/src/views/resources/ResourcesView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, useRoute } from 'vue-router'
 
 import { useResourceStore } from '@/stores/resourceStore'
 import { useComponentStore } from '@/stores/componentStore'
@@ -16,11 +16,14 @@ import type { Resource } from '@/types'
 const resourceStore = useResourceStore()
 const componentStore = useComponentStore()
 const router = useRouter()
+const route = useRoute()
 
 const filters = useResourceFilters()
 
 const showModal = ref(false)
 const editingResource = ref<Resource | null>(null)
+// Seed for "create from Toolbox" CTAs (spec 071): /resources?create=1&type=&target=
+const createSeed = ref<{ type?: string; target?: string; name?: string } | null>(null)
 const collapsedGroups = ref<Record<string, boolean>>({})
 
 const selectedIds = ref<string[]>([])
@@ -115,6 +118,7 @@ function setCollapsed(key: string, v: boolean) {
 
 function openCreate() {
   editingResource.value = null
+  createSeed.value = null
   showModal.value = true
 }
 
@@ -148,6 +152,18 @@ async function onFormSubmit() {
 
 onMounted(async () => {
   await Promise.all([resourceStore.loadResources(), componentStore.loadComponents()])
+  // Open the create modal pre-seeded when arriving from a Toolbox "Create monitor" CTA.
+  if (route.query.create === '1') {
+    createSeed.value = {
+      type: typeof route.query.type === 'string' ? route.query.type : undefined,
+      target: typeof route.query.target === 'string' ? route.query.target : undefined,
+      name: typeof route.query.name === 'string' ? route.query.name : undefined,
+    }
+    editingResource.value = null
+    showModal.value = true
+    // Drop the query so a refresh / back doesn't reopen it.
+    void router.replace({ query: {} })
+  }
 })
 
 defineExpose({
@@ -330,7 +346,12 @@ defineExpose({
       </template>
     </div>
 
-    <ResourceModal v-model:open="showModal" :resource="editingResource" @submit="onFormSubmit" />
+    <ResourceModal
+      v-model:open="showModal"
+      :resource="editingResource"
+      :initial="createSeed"
+      @submit="onFormSubmit"
+    />
     <GroupResourcesModal
       v-model:open="showGroupModal"
       :selected-ids="selectedIds"

--- a/web/src/views/toolbox/DnsToolView.vue
+++ b/web/src/views/toolbox/DnsToolView.vue
@@ -1,0 +1,216 @@
+<script setup lang="ts">
+/**
+ * DNS Lookup tool (spec 071, US1).
+ * Form (domain + record types + resolver) → results table + session history.
+ */
+import { reactive, ref, computed } from 'vue'
+import { useToast } from '@nuxt/ui/composables/useToast'
+import { dnsLookupSchema, dnsRecordTypes } from '@/schemas/toolbox-dns.schema'
+import { dnsLookup } from '@/services/toolboxService'
+import type { DnsLookupRequest, DnsRecord, DnsHistoryEntry, DnsRecordType, DnsResolver } from '@/types/toolbox'
+
+const toast = useToast()
+
+const state = reactive<{
+  domain: string
+  record_types: DnsRecordType[]
+  resolver: DnsResolver
+  custom_resolver: string
+}>({
+  domain: '',
+  record_types: ['A'],
+  resolver: 'cloudflare',
+  custom_resolver: '',
+})
+
+const recordTypeItems = dnsRecordTypes.map((t) => ({ label: t, value: t }))
+const resolverItems = [
+  { label: '1.1.1.1 (Cloudflare)', value: 'cloudflare' },
+  { label: '8.8.8.8 (Google)', value: 'google' },
+  { label: '9.9.9.9 (Quad9)', value: 'quad9' },
+  { label: 'Custom…', value: 'custom' },
+]
+
+const loading = ref(false)
+const records = ref<DnsRecord[]>([])
+const queryMs = ref<number | null>(null)
+const resolverUsed = ref('')
+const ran = ref(false)
+const history = ref<DnsHistoryEntry[]>(loadHistory())
+let controller: AbortController | null = null
+
+const summary = computed(() =>
+  queryMs.value === null ? '' : `${records.value.length} records · ${queryMs.value}ms`,
+)
+
+function loadHistory(): DnsHistoryEntry[] {
+  try {
+    const raw = sessionStorage.getItem('toolbox.dns.history')
+    return raw ? (JSON.parse(raw) as DnsHistoryEntry[]) : []
+  } catch {
+    return []
+  }
+}
+
+function pushHistory(req: DnsLookupRequest) {
+  history.value = [{ request: req, at: Date.now() }, ...history.value].slice(0, 10)
+  try {
+    sessionStorage.setItem('toolbox.dns.history', JSON.stringify(history.value))
+  } catch {
+    /* sessionStorage may be unavailable; non-fatal */
+  }
+}
+
+async function run() {
+  const payload: DnsLookupRequest = {
+    domain: state.domain.trim(),
+    record_types: state.record_types,
+    resolver: state.resolver,
+    custom_resolver: state.resolver === 'custom' ? state.custom_resolver.trim() : undefined,
+  }
+  loading.value = true
+  ran.value = true
+  controller = new AbortController()
+  try {
+    const res = await dnsLookup(payload, controller.signal)
+    records.value = res.records
+    queryMs.value = res.query_ms
+    resolverUsed.value = res.resolver_used
+    pushHistory(payload)
+  } catch (e) {
+    if ((e as Error)?.name !== 'AbortError') {
+      toast.add({ title: 'DNS lookup failed', description: (e as Error)?.message, color: 'error' })
+    }
+  } finally {
+    loading.value = false
+    controller = null
+  }
+}
+
+function cancel() {
+  controller?.abort()
+  loading.value = false
+}
+
+function rerun(entry: DnsHistoryEntry) {
+  state.domain = entry.request.domain
+  state.record_types = entry.request.record_types
+  state.resolver = entry.request.resolver
+  state.custom_resolver = entry.request.custom_resolver ?? ''
+  void run()
+}
+
+async function copy(value: string) {
+  try {
+    await navigator.clipboard.writeText(value)
+    toast.add({ title: 'Copied', color: 'success' })
+  } catch {
+    toast.add({ title: 'Copy failed', color: 'error' })
+  }
+}
+</script>
+
+<template>
+  <div class="flex flex-col lg:flex-row gap-6">
+    <!-- Form -->
+    <div class="w-full lg:w-[380px] shrink-0 flex flex-col gap-4">
+      <UForm :schema="dnsLookupSchema" :state="state" class="flex flex-col gap-4" @submit="run">
+        <UFormField label="Domain" name="domain">
+          <UInput v-model="state.domain" placeholder="example.com" class="w-full" />
+        </UFormField>
+
+        <UFormField label="Record types" name="record_types">
+          <USelect
+            v-model="state.record_types"
+            :items="recordTypeItems"
+            multiple
+            class="w-full"
+          />
+        </UFormField>
+
+        <UFormField label="Resolver" name="resolver">
+          <USelect v-model="state.resolver" :items="resolverItems" class="w-full" />
+        </UFormField>
+
+        <UFormField
+          v-if="state.resolver === 'custom'"
+          label="Custom resolver"
+          name="custom_resolver"
+        >
+          <UInput v-model="state.custom_resolver" placeholder="192.0.2.1" class="w-full" />
+        </UFormField>
+
+        <div class="flex gap-2">
+          <UButton type="submit" :loading="loading" icon="i-lucide-play">Run Lookup</UButton>
+          <UButton v-if="loading" color="neutral" variant="subtle" @click="cancel">Cancel</UButton>
+        </div>
+      </UForm>
+
+      <UAlert
+        icon="i-lucide-info"
+        color="info"
+        variant="subtle"
+        title="Monitor this continuously?"
+        description="Save it as a DNS monitor to track changes over time."
+      />
+
+      <!-- History -->
+      <div v-if="history.length" class="flex flex-col gap-2">
+        <div class="text-xs font-medium text-muted uppercase tracking-wide">Recent lookups</div>
+        <button
+          v-for="(entry, i) in history"
+          :key="i"
+          class="flex items-center justify-between px-2 py-1.5 rounded-md text-sm text-muted hover:bg-elevated hover:text-default transition-colors text-left"
+          @click="rerun(entry)"
+        >
+          <span class="font-mono truncate">{{ entry.request.domain }}</span>
+          <span class="text-xs">{{ entry.request.record_types.join(', ') }}</span>
+        </button>
+      </div>
+    </div>
+
+    <!-- Results -->
+    <div class="flex-1 min-w-0">
+      <div v-if="ran && !loading" class="flex flex-col gap-3">
+        <div class="flex items-center gap-2">
+          <UBadge v-if="records.length" color="success" variant="subtle">{{ summary }}</UBadge>
+          <UBadge v-else color="neutral" variant="subtle">No records found</UBadge>
+          <span v-if="resolverUsed" class="text-xs text-muted font-mono">via {{ resolverUsed }}</span>
+        </div>
+
+        <div v-if="records.length" class="overflow-x-auto rounded-lg border border-default">
+          <table class="w-full text-sm">
+            <thead class="bg-elevated text-muted">
+              <tr>
+                <th class="text-left font-medium px-3 py-2">Type</th>
+                <th class="text-left font-medium px-3 py-2">Value</th>
+                <th class="text-left font-medium px-3 py-2">TTL</th>
+                <th class="px-3 py-2"></th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(rec, i) in records" :key="i" class="border-t border-default">
+                <td class="px-3 py-2"><UBadge variant="subtle" size="sm">{{ rec.type }}</UBadge></td>
+                <td class="px-3 py-2 font-mono break-all">{{ rec.value }}</td>
+                <td class="px-3 py-2 text-muted">{{ rec.ttl || '—' }}</td>
+                <td class="px-3 py-2 text-right">
+                  <UButton
+                    icon="i-lucide-copy"
+                    color="neutral"
+                    variant="ghost"
+                    size="xs"
+                    @click="copy(rec.value)"
+                  />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div v-else-if="!ran" class="flex items-center justify-center h-40 text-muted text-sm">
+        Enter a domain and run a lookup.
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/src/views/toolbox/PortToolView.vue
+++ b/web/src/views/toolbox/PortToolView.vue
@@ -1,0 +1,158 @@
+<script setup lang="ts">
+/**
+ * Port Scanner tool (spec 071, US3).
+ * Target must be a registered monitor host (backend gates with 403). Presets
+ * auto-populate the ports field; results show open/closed/filtered per port.
+ */
+import { reactive, ref, computed, watch } from 'vue'
+import { useToast } from '@nuxt/ui/composables/useToast'
+import { portScanSchema, portPresets, portPresetValues } from '@/schemas/toolbox-port.schema'
+import { portScan } from '@/services/toolboxService'
+import type { PortResult, PortPreset } from '@/types/toolbox'
+
+const toast = useToast()
+
+const state = reactive<{ target: string; preset: PortPreset; portsText: string; timeout_ms: number }>({
+  target: '',
+  preset: 'common',
+  portsText: portPresetValues.common.join(', '),
+  timeout_ms: 1000,
+})
+
+const presetItems = portPresets.map((p) => ({ label: p.charAt(0).toUpperCase() + p.slice(1), value: p }))
+
+// Selecting a preset (other than custom) repopulates the ports field.
+watch(
+  () => state.preset,
+  (p) => {
+    if (p !== 'custom') state.portsText = portPresetValues[p].join(', ')
+  },
+)
+
+const loading = ref(false)
+const results = ref<PortResult[]>([])
+const openCount = ref(0)
+const scannedCount = ref(0)
+const ran = ref(false)
+let controller: AbortController | null = null
+
+const summary = computed(() => (ran.value ? `${openCount.value} open / ${scannedCount.value} scanned` : ''))
+
+function parsePorts(text: string): number[] {
+  return text
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => Number(s))
+}
+
+function statusColor(status: string): 'success' | 'neutral' | 'warning' {
+  if (status === 'open') return 'success'
+  if (status === 'filtered') return 'warning'
+  return 'neutral'
+}
+
+async function run() {
+  const payload = {
+    target: state.target.trim(),
+    preset: state.preset,
+    ports: parsePorts(state.portsText),
+    timeout_ms: state.timeout_ms,
+  }
+  const parsed = portScanSchema.safeParse(payload)
+  if (!parsed.success) {
+    toast.add({ title: 'Invalid input', description: parsed.error.issues[0]?.message, color: 'error' })
+    return
+  }
+  loading.value = true
+  ran.value = true
+  controller = new AbortController()
+  try {
+    const res = await portScan(
+      { target: payload.target, ports: payload.ports, preset: payload.preset, timeout_ms: payload.timeout_ms },
+      controller.signal,
+    )
+    results.value = res.results
+    openCount.value = res.open_count
+    scannedCount.value = res.scanned_count
+  } catch (e) {
+    if ((e as Error)?.name !== 'AbortError') {
+      toast.add({ title: 'Port scan failed', description: (e as Error)?.message, color: 'error' })
+    }
+  } finally {
+    loading.value = false
+    controller = null
+  }
+}
+
+function cancel() {
+  controller?.abort()
+  loading.value = false
+}
+</script>
+
+<template>
+  <div class="flex flex-col lg:flex-row gap-6">
+    <div class="w-full lg:w-[380px] shrink-0 flex flex-col gap-4">
+      <UFormField label="Target host" name="target">
+        <UInput v-model="state.target" placeholder="db-prod-01.internal" class="w-full font-mono" />
+      </UFormField>
+
+      <UFormField label="Preset" name="preset">
+        <USelect v-model="state.preset" :items="presetItems" class="w-full" />
+      </UFormField>
+
+      <UFormField label="Ports" name="ports" hint="comma or space separated, max 100">
+        <UTextarea v-model="state.portsText" :rows="3" class="w-full font-mono" />
+      </UFormField>
+
+      <UFormField label="Timeout (ms)" name="timeout_ms">
+        <UInput v-model.number="state.timeout_ms" type="number" :min="100" :max="2000" class="w-full" />
+      </UFormField>
+
+      <div class="flex gap-2">
+        <UButton :loading="loading" icon="i-lucide-play" @click="run">Run</UButton>
+        <UButton v-if="loading" color="neutral" variant="subtle" @click="cancel">Cancel</UButton>
+      </div>
+
+      <UAlert
+        icon="i-lucide-shield"
+        color="neutral"
+        variant="subtle"
+        title="Registered hosts only"
+        description="Scans are limited to hosts already monitored, rate-limited, and audited."
+      />
+    </div>
+
+    <div class="flex-1 min-w-0">
+      <div v-if="ran && !loading" class="flex flex-col gap-3">
+        <UBadge color="primary" variant="subtle">{{ summary }}</UBadge>
+        <div v-if="results.length" class="overflow-x-auto rounded-lg border border-default">
+          <table class="w-full text-sm">
+            <thead class="bg-elevated text-muted">
+              <tr>
+                <th class="text-left font-medium px-3 py-2">Port</th>
+                <th class="text-left font-medium px-3 py-2">Service</th>
+                <th class="text-left font-medium px-3 py-2">Status</th>
+                <th class="text-left font-medium px-3 py-2">Banner</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="(r, i) in results" :key="i" class="border-t border-default">
+                <td class="px-3 py-2 font-mono">{{ r.port }}</td>
+                <td class="px-3 py-2 text-muted">{{ r.service || '—' }}</td>
+                <td class="px-3 py-2">
+                  <UBadge :color="statusColor(r.status)" variant="subtle" size="sm">{{ r.status }}</UBadge>
+                </td>
+                <td class="px-3 py-2 font-mono text-xs text-muted break-all">{{ r.banner || '—' }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div v-else-if="!ran" class="flex items-center justify-center h-40 text-muted text-sm">
+        Enter a registered host and run a scan.
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/src/views/toolbox/SslToolView.vue
+++ b/web/src/views/toolbox/SslToolView.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+/**
+ * SSL Checker tool (spec 071, US2).
+ * Inspects a TLS certificate, warns when it expires within 14 days, lists
+ * passive vulnerability indicators, and offers "Add as monitor".
+ */
+import { reactive, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useToast } from '@nuxt/ui/composables/useToast'
+import { sslCheckSchema } from '@/schemas/toolbox-ssl.schema'
+import { sslCheck } from '@/services/toolboxService'
+import type { SslCheckResponse } from '@/types/toolbox'
+
+const toast = useToast()
+const router = useRouter()
+
+const state = reactive<{ domain: string; port: number }>({ domain: '', port: 443 })
+
+const loading = ref(false)
+const result = ref<SslCheckResponse | null>(null)
+let controller: AbortController | null = null
+
+async function run() {
+  loading.value = true
+  controller = new AbortController()
+  try {
+    result.value = await sslCheck({ domain: state.domain.trim(), port: state.port }, controller.signal)
+  } catch (e) {
+    if ((e as Error)?.name !== 'AbortError') {
+      result.value = null
+      toast.add({ title: 'SSL check failed', description: (e as Error)?.message, color: 'error' })
+    }
+  } finally {
+    loading.value = false
+    controller = null
+  }
+}
+
+function cancel() {
+  controller?.abort()
+  loading.value = false
+}
+
+function addAsMonitor() {
+  router.push({
+    path: '/resources',
+    query: { create: '1', type: 'http', target: `https://${state.domain.trim()}` },
+  })
+}
+
+function vulnColor(status: string): 'success' | 'warning' {
+  return status === 'pass' ? 'success' : 'warning'
+}
+</script>
+
+<template>
+  <div class="flex flex-col lg:flex-row gap-6">
+    <div class="w-full lg:w-[380px] shrink-0 flex flex-col gap-4">
+      <UForm :schema="sslCheckSchema" :state="state" class="flex flex-col gap-4" @submit="run">
+        <UFormField label="Domain" name="domain">
+          <UInput v-model="state.domain" placeholder="example.com" class="w-full" />
+        </UFormField>
+        <UFormField label="Port" name="port">
+          <UInput v-model.number="state.port" type="number" :min="1" :max="65535" class="w-full" />
+        </UFormField>
+        <div class="flex gap-2">
+          <UButton type="submit" :loading="loading" icon="i-lucide-play">Run</UButton>
+          <UButton v-if="loading" color="neutral" variant="subtle" @click="cancel">Cancel</UButton>
+        </div>
+      </UForm>
+    </div>
+
+    <div class="flex-1 min-w-0">
+      <div v-if="result" class="flex flex-col gap-4">
+        <UAlert
+          v-if="result.expiring_soon"
+          icon="i-lucide-alert-triangle"
+          color="warning"
+          variant="subtle"
+          :title="`Certificate expires in ${result.days_to_expiry} days`"
+          :description="`Renew before ${result.certificate.valid_to}`"
+        >
+          <template #actions>
+            <UButton size="xs" color="warning" @click="addAsMonitor">Add as monitor</UButton>
+          </template>
+        </UAlert>
+
+        <!-- Certificate details -->
+        <div class="rounded-lg border border-default p-4 flex flex-col gap-2 text-sm">
+          <div class="font-medium text-highlighted">Certificate</div>
+          <dl class="grid grid-cols-[120px_1fr] gap-y-1">
+            <dt class="text-muted">Subject</dt><dd class="font-mono break-all">{{ result.certificate.subject }}</dd>
+            <dt class="text-muted">Issuer</dt><dd>{{ result.certificate.issuer }}</dd>
+            <dt class="text-muted">Valid from</dt><dd>{{ result.certificate.valid_from }}</dd>
+            <dt class="text-muted">Valid to</dt><dd>{{ result.certificate.valid_to }}</dd>
+            <dt class="text-muted">Cipher</dt><dd class="font-mono">{{ result.certificate.cipher }}</dd>
+            <dt class="text-muted">SANs</dt><dd class="font-mono break-all">{{ result.certificate.sans.join(', ') || '—' }}</dd>
+            <dt class="text-muted">Chain</dt><dd class="font-mono break-all">{{ result.certificate.chain.join(' → ') || '—' }}</dd>
+          </dl>
+        </div>
+
+        <!-- Vulnerability checks -->
+        <div class="rounded-lg border border-default p-4 flex flex-col gap-2 text-sm">
+          <div class="font-medium text-highlighted">Vulnerability checks</div>
+          <div class="flex flex-wrap gap-2">
+            <div v-for="v in result.vulnerabilities" :key="v.name" class="flex items-center gap-2">
+              <UBadge :color="vulnColor(v.status)" variant="subtle" size="sm">
+                {{ v.name }}: {{ v.status }}
+              </UBadge>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div v-else-if="!loading" class="flex items-center justify-center h-40 text-muted text-sm">
+        Enter a domain to inspect its certificate.
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/src/views/toolbox/ToolboxLayoutView.vue
+++ b/web/src/views/toolbox/ToolboxLayoutView.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+/**
+ * Toolbox shell (spec 071) — route-synced tabs over <RouterView/>.
+ * Four one-shot network tools: DNS / Port / SSL / WHOIS.
+ * Pattern mirrors SettingsLayoutView (RouterLink tab bar + useRoute active state).
+ */
+import { RouterLink, RouterView, useRoute } from 'vue-router'
+
+interface Tab {
+  label: string
+  to: string
+  icon: string
+}
+
+const tabs: Tab[] = [
+  { label: 'DNS Lookup', to: '/toolbox/dns', icon: 'i-lucide-globe' },
+  { label: 'Port Scanner', to: '/toolbox/port', icon: 'i-lucide-radar' },
+  { label: 'SSL Checker', to: '/toolbox/ssl', icon: 'i-lucide-lock' },
+  { label: 'WHOIS', to: '/toolbox/whois', icon: 'i-lucide-file-search' },
+]
+
+const route = useRoute()
+const isActive = (to: string) => route.path === to || route.path.startsWith(`${to}/`)
+</script>
+
+<template>
+  <div class="flex flex-col gap-6 w-full min-h-full bg-default text-default">
+    <header class="flex flex-col gap-1">
+      <h1 class="text-2xl font-bold text-highlighted">Toolbox</h1>
+      <p class="text-sm text-muted">Run one-off network checks</p>
+    </header>
+
+    <nav class="flex gap-1 border-b border-default">
+      <RouterLink
+        v-for="tab in tabs"
+        :key="tab.to"
+        :to="tab.to"
+        class="flex items-center gap-2 px-3 py-2 text-sm border-b-2 -mb-px transition-colors"
+        :class="
+          isActive(tab.to)
+            ? 'border-primary-500 text-highlighted font-medium'
+            : 'border-transparent text-muted hover:text-default'
+        "
+      >
+        <UIcon :name="tab.icon" class="size-4" />
+        <span>{{ tab.label }}</span>
+      </RouterLink>
+    </nav>
+
+    <RouterView />
+  </div>
+</template>

--- a/web/src/views/toolbox/WhoisToolView.vue
+++ b/web/src/views/toolbox/WhoisToolView.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+/**
+ * WHOIS tool (spec 071, US4).
+ * Domain registration lookup + "Create monitor" CTA to track expiry.
+ */
+import { reactive, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useToast } from '@nuxt/ui/composables/useToast'
+import { whoisSchema } from '@/schemas/toolbox-whois.schema'
+import { whoisLookup } from '@/services/toolboxService'
+import type { WhoisResponse } from '@/types/toolbox'
+
+const toast = useToast()
+const router = useRouter()
+
+const state = reactive<{ domain: string }>({ domain: '' })
+
+const loading = ref(false)
+const result = ref<WhoisResponse | null>(null)
+let controller: AbortController | null = null
+
+async function run() {
+  loading.value = true
+  controller = new AbortController()
+  try {
+    result.value = await whoisLookup({ domain: state.domain.trim() }, controller.signal)
+  } catch (e) {
+    if ((e as Error)?.name !== 'AbortError') {
+      result.value = null
+      toast.add({ title: 'WHOIS lookup failed', description: (e as Error)?.message, color: 'error' })
+    }
+  } finally {
+    loading.value = false
+    controller = null
+  }
+}
+
+function cancel() {
+  controller?.abort()
+  loading.value = false
+}
+
+function createMonitor() {
+  router.push({
+    path: '/resources',
+    query: { create: '1', type: 'http', target: `https://${state.domain.trim()}` },
+  })
+}
+</script>
+
+<template>
+  <div class="flex flex-col lg:flex-row gap-6">
+    <div class="w-full lg:w-[380px] shrink-0 flex flex-col gap-4">
+      <UForm :schema="whoisSchema" :state="state" class="flex flex-col gap-4" @submit="run">
+        <UFormField label="Domain" name="domain">
+          <UInput v-model="state.domain" placeholder="example.com" class="w-full" />
+        </UFormField>
+        <div class="flex gap-2">
+          <UButton type="submit" :loading="loading" icon="i-lucide-play">Run</UButton>
+          <UButton v-if="loading" color="neutral" variant="subtle" @click="cancel">Cancel</UButton>
+        </div>
+      </UForm>
+    </div>
+
+    <div class="flex-1 min-w-0">
+      <div v-if="result" class="flex flex-col gap-4">
+        <!-- Domain card -->
+        <div class="rounded-lg border border-default p-4 flex flex-col gap-3 text-sm">
+          <div class="flex items-center justify-between">
+            <span class="font-medium text-highlighted">{{ state.domain }}</span>
+            <UBadge v-if="result.days_to_expiry > 0" color="success" variant="subtle">
+              Active · {{ result.days_to_expiry }}d remaining
+            </UBadge>
+          </div>
+          <dl class="grid grid-cols-[120px_1fr] gap-y-1">
+            <dt class="text-muted">Registrar</dt><dd>{{ result.registrar || '—' }}</dd>
+            <dt class="text-muted">Registered</dt><dd>{{ result.registered_at || '—' }}</dd>
+            <dt class="text-muted">Updated</dt><dd>{{ result.updated_at || '—' }}</dd>
+            <dt class="text-muted">Expires</dt><dd>{{ result.expires_at || '—' }}</dd>
+            <dt class="text-muted">Status</dt><dd class="font-mono break-all">{{ result.status.join(', ') || '—' }}</dd>
+            <dt class="text-muted">Privacy</dt><dd>{{ result.privacy ? 'Enabled' : 'Disabled' }}</dd>
+            <dt class="text-muted">DNSSEC</dt><dd>{{ result.dnssec ? 'Signed' : 'Unsigned' }}</dd>
+          </dl>
+        </div>
+
+        <!-- Nameservers -->
+        <div class="rounded-lg border border-default p-4 flex flex-col gap-2 text-sm">
+          <div class="font-medium text-highlighted">Nameservers</div>
+          <ul class="font-mono text-muted">
+            <li v-for="ns in result.nameservers" :key="ns">{{ ns }}</li>
+            <li v-if="!result.nameservers.length">—</li>
+          </ul>
+        </div>
+
+        <UAlert
+          icon="i-lucide-calendar-clock"
+          color="primary"
+          variant="subtle"
+          title="Track this domain's expiry automatically"
+          description="Set up a monitor to be alerted before it expires."
+        >
+          <template #actions>
+            <UButton size="xs" color="primary" @click="createMonitor">Create monitor</UButton>
+          </template>
+        </UAlert>
+      </div>
+      <div v-else-if="!loading" class="flex items-center justify-center h-40 text-muted text-sm">
+        Enter a domain to look up its registration.
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/src/views/toolbox/__tests__/DnsToolView.spec.ts
+++ b/web/src/views/toolbox/__tests__/DnsToolView.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('@nuxt/ui/composables/useToast', () => ({ useToast: () => ({ add: vi.fn() }) }))
+vi.mock('@/services/toolboxService', () => ({ dnsLookup: vi.fn() }))
+
+import DnsToolView from '../DnsToolView.vue'
+
+const stubs = {
+  UForm: { template: '<form><slot /></form>' },
+  UFormField: { template: '<div><slot /></div>' },
+  UInput: { template: '<input />' },
+  USelect: { template: '<select />' },
+  UButton: { template: '<button><slot /></button>' },
+  UAlert: { template: '<div />' },
+  UBadge: { template: '<span><slot /></span>' },
+  UIcon: { template: '<span />' },
+}
+
+describe('DnsToolView', () => {
+  it('mounts and shows the empty state', () => {
+    const w = mount(DnsToolView, { global: { stubs } })
+    expect(w.text()).toContain('Enter a domain')
+    // form + run button render
+    expect(w.find('form').exists()).toBe(true)
+  })
+})

--- a/web/src/views/toolbox/__tests__/PortToolView.spec.ts
+++ b/web/src/views/toolbox/__tests__/PortToolView.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('@nuxt/ui/composables/useToast', () => ({ useToast: () => ({ add: vi.fn() }) }))
+const portScan = vi.fn()
+vi.mock('@/services/toolboxService', () => ({ portScan: (...a: unknown[]) => portScan(...a) }))
+
+import PortToolView from '../PortToolView.vue'
+import { portPresetValues } from '@/schemas/toolbox-port.schema'
+
+const stubs = {
+  UFormField: { template: '<div><slot /></div>' },
+  UInput: { template: '<input />' },
+  USelect: { template: '<select />' },
+  UTextarea: { template: '<textarea />' },
+  UButton: { template: '<button><slot /></button>' },
+  UAlert: { template: '<div />' },
+  UBadge: { template: '<span><slot /></span>' },
+}
+
+beforeEach(() => portScan.mockReset())
+
+describe('PortToolView', () => {
+  it('shows empty state before a run', () => {
+    expect(mount(PortToolView, { global: { stubs } }).text()).toContain('Enter a registered host')
+  })
+
+  it('default ports text matches the common preset', () => {
+    const w = mount(PortToolView, { global: { stubs } })
+    // The component seeds portsText from the common preset on creation.
+    expect((w.vm as unknown as { state: { portsText: string } }).state.portsText).toContain(
+      String(portPresetValues.common[0]),
+    )
+  })
+})

--- a/web/src/views/toolbox/__tests__/SslToolView.spec.ts
+++ b/web/src/views/toolbox/__tests__/SslToolView.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('@nuxt/ui/composables/useToast', () => ({ useToast: () => ({ add: vi.fn() }) }))
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: vi.fn() }), useRoute: () => ({ query: {}, params: {}, path: '/toolbox/ssl' }) }))
+vi.mock('@/services/toolboxService', () => ({ sslCheck: vi.fn() }))
+
+import SslToolView from '../SslToolView.vue'
+
+const stubs = {
+  UForm: { template: '<form><slot /></form>' },
+  UFormField: { template: '<div><slot /></div>' },
+  UInput: { template: '<input />' },
+  UButton: { template: '<button><slot /></button>' },
+  UAlert: { template: '<div />' },
+  UBadge: { template: '<span><slot /></span>' },
+}
+
+describe('SslToolView', () => {
+  it('mounts and shows the empty state', () => {
+    expect(mount(SslToolView, { global: { stubs } }).text()).toContain('Enter a domain')
+  })
+})

--- a/web/src/views/toolbox/__tests__/WhoisToolView.spec.ts
+++ b/web/src/views/toolbox/__tests__/WhoisToolView.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+vi.mock('@nuxt/ui/composables/useToast', () => ({ useToast: () => ({ add: vi.fn() }) }))
+vi.mock('vue-router', () => ({ useRouter: () => ({ push: vi.fn() }), useRoute: () => ({ query: {}, params: {}, path: '/toolbox/whois' }) }))
+vi.mock('@/services/toolboxService', () => ({ whoisLookup: vi.fn() }))
+
+import WhoisToolView from '../WhoisToolView.vue'
+
+const stubs = {
+  UForm: { template: '<form><slot /></form>' },
+  UFormField: { template: '<div><slot /></div>' },
+  UInput: { template: '<input />' },
+  UButton: { template: '<button><slot /></button>' },
+  UAlert: { template: '<div />' },
+  UBadge: { template: '<span><slot /></span>' },
+}
+
+describe('WhoisToolView', () => {
+  it('mounts and shows the empty state', () => {
+    expect(mount(WhoisToolView, { global: { stubs } }).text()).toContain('Enter a domain')
+  })
+})


### PR DESCRIPTION
## What

Implements spec 071 — a server-side **network Toolbox** (one-shot DNS lookup,
port scan, SSL/cert check, WHOIS) plus a static **Prometheus Metrics** doc page.
Adds the TOOLS section to the sidebar. Last major frontend PRD (011) from the
refonte roadmap.

## Backend (`/api/v1/toolbox/*`)

- `POST /dns` — A/AAAA/MX/NS/TXT/CNAME, resolver selection (Cloudflare/Google/Quad9/custom)
- `POST /port-scan` — restricted to **registered monitor hosts only**, max 100 ports, timeout 100–2000ms
- `POST /ssl-check` — cert details + passive vulnerability heuristics, `expiring_soon` (<14d)
- `POST /whois` — registrar/expiry/nameservers/DNSSEC

All targets validated through `pkg/safenet` (SSRF / blocked-IP guard). Endpoints
are write-scoped (`RequireReadWrite`) and per-user rate-limited (DNS/SSL/WHOIS
20/min, port 5/min); every run is audit-logged via `slog` (`category=toolbox`).

**No migration, no sqlc change, no new dependency** — reuses `likexian/whois`
(already vendored), stdlib `net`/`crypto/tls`, and existing `safenet` + middleware.

## Frontend

- Toolbox shell with route-synced tabs (`/toolbox/{dns,port,ssl,whois}`) + `/metrics`
- `toolboxService` (Ky, envelope unwrap, AbortController cancellation), Zod schemas per tool
- DNS session history, SSL expiry alert + vuln pills, port-range presets
- **Convert-to-monitor**: SSL/WHOIS CTAs open the resource modal pre-seeded
  (`initial {type,target}` on ResourceForm/Modal, read from route query)
- Metrics page: endpoint URL + masked token, metric catalog, copyable scrape config, curl example

## Tests

`make ci-local` ✅ — sqlc/migrations drift, lint (go vet + oxlint + eslint),
backend race tests, **frontend 718/718**, license-audit all green.
New coverage: 27 backend (service + handler, incl. negative paths: 403 unregistered
target, 403 SSRF, 400 validation, 422 cert/whois) + 25 frontend (service MSW, 4 schemas, 6 views).

## Known follow-ups (out of scope here)

- **DNS TTL** returned as `0` — stdlib `net.Resolver` doesn't expose TTL; needs
  `miekg/dns` if real TTL is wanted (deferred to keep the no-new-dep promise).
- `make swag` regen is blocked by a **pre-existing** annotation bug in
  `public_status_handler.go` (`dto.ProblemDetails`), unrelated to this PR — toolbox
  Swagger annotations are written and will emit once that's fixed.

## Notes for reviewer

- Port-scanner abuse guard intentionally limits targets to already-registered
  monitor hosts (resolved in Go against existing resources — no schema change).
- Metrics page is documentation-only (live scrape stats out of scope per spec).