### PR TITLE
feat(agent): host metrics agent binary + shared frame contract (spec 080)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/079-agent-host-foundation"
+  "feature_directory": "specs/080-host-metrics-agent"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,18 @@ linked in the release notes.
   `host_credentials`, `host_metrics`, and a nullable `resources.host_id`. The
   agent is strictly optional — no core monitoring path depends on a host. The
   agent binary and UI are separate, forthcoming chantiers.
+- **Host agent binary (spec 080)** — `cmd/agent`, the Go daemon installed on a
+  monitored Linux host. Collects OS, CPU %, memory %, per-mount disk %, and
+  network counters via gopsutil and streams them to `/api/v1/agent/stream` every
+  ~10s, authenticated by the host's `ag_live_…` credential. Config from
+  `/etc/ogoune-agent.yaml` with env/flag overrides; a systemd unit is provided
+  (`packaging/agent/`). Fail-safe: reconnects with exponential back-off, and on a
+  revoked credential slows to a capped (~5 min) infinite back-off so it self-heals
+  when the credential is re-validated — never crashing the host, never
+  tight-looping. Build with `make build-agent`. The agent↔backend frame is a
+  single shared contract (`pkg/agentwire`, carrying `schema_version`) imported by
+  both sides so they cannot drift; the 079 ingestion handler adopts it
+  backward-compatibly (a frame with no `schema_version` is treated as v1).
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,5 +229,5 @@ Dashboard: http://localhost:9009 (project `ogoune`). Block on CRITICAL/BLOCKER i
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/078-bulk-resource-import/plan.md`
+`specs/080-host-metrics-agent/plan.md`
 <!-- SPECKIT END -->

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ build-be: sqlc-check
 	mkdir -p dist
 	go build -o $(BINARY) ./cmd/api/main.go
 
+# Host monitoring agent binary (spec 080). Version is stamped from git.
+build-agent:
+	mkdir -p dist
+	go build -ldflags "-X main.version=$$(git describe --tags --always --dirty 2>/dev/null || echo dev)" -o dist/ogoune-agent ./cmd/agent
+
 SQLC_BIN := $(shell go env GOPATH)/bin/sqlc
 
 sqlc-bin:

--- a/cmd/agent/README.md
+++ b/cmd/agent/README.md
@@ -1,0 +1,90 @@
+# Ogoune host agent (`ogoune-agent`)
+
+The optional host monitoring agent (spec 080). It runs on a monitored Linux
+server, collects system metrics, and streams them to the Ogoune backend over the
+`/api/v1/agent/stream` WebSocket, authenticated by a per-host `ag_live_…`
+credential. The agent is **optional** — no core monitoring capability depends on
+it — and **fail-safe**: it never crashes the host, retries on failure, and slows
+to a capped back-off on a revoked credential.
+
+## Build
+
+```bash
+make build-agent          # → dist/ogoune-agent (version stamped from git)
+# or: go build -o dist/ogoune-agent ./cmd/agent
+```
+
+## Register a host (operator)
+
+```bash
+curl -sS -X POST https://ogoune.example.com/api/v1/hosts \
+  -H "Authorization: Bearer <operator-api-key>" \
+  -H "Content-Type: application/json" -d '{"name":"web-1"}'
+# → { "data": { "host": {...}, "credential": "ag_live_…" } }   (credential shown once)
+```
+
+## Configure
+
+Config precedence: **flags > environment > file > defaults**.
+
+Config file (default `/etc/ogoune-agent.yaml`, mode `0600`) — see
+[`packaging/agent/ogoune-agent.example.yaml`](../../packaging/agent/ogoune-agent.example.yaml):
+
+```yaml
+backend_url: wss://ogoune.example.com/api/v1/agent/stream   # required
+credential: ag_live_…                                       # required
+interval: 10s          # optional (default 10s)
+log_level: info        # optional (debug|info|warn|error)
+insecure_skip_verify: false   # dev/self-signed only
+```
+
+| Setting | Flag | Env |
+|---|---|---|
+| backend URL | `--backend-url` | `OGOUNE_BACKEND_URL` |
+| credential | `--credential` | `OGOUNE_CREDENTIAL` |
+| interval | `--interval` | `OGOUNE_INTERVAL` |
+| log level | `--log-level` | `OGOUNE_LOG_LEVEL` |
+| insecure TLS | `--insecure` | `OGOUNE_INSECURE` |
+| config path | `--config` | `OGOUNE_CONFIG` |
+
+## Run
+
+Ad-hoc:
+
+```bash
+OGOUNE_BACKEND_URL=wss://ogoune.example.com/api/v1/agent/stream \
+OGOUNE_CREDENTIAL=ag_live_… ./dist/ogoune-agent
+```
+
+As a service (systemd), using
+[`packaging/agent/ogoune-agent.service`](../../packaging/agent/ogoune-agent.service):
+
+```bash
+sudo install -m755 dist/ogoune-agent /usr/local/bin/ogoune-agent
+sudo install -m600 packaging/agent/ogoune-agent.example.yaml /etc/ogoune-agent.yaml   # then edit
+sudo install -m644 packaging/agent/ogoune-agent.service /etc/systemd/system/
+sudo systemctl daemon-reload && sudo systemctl enable --now ogoune-agent
+journalctl -u ogoune-agent -f
+```
+
+## Behaviour
+
+- **Cadence**: one metric frame per `interval` (~10s). The backend assigns the
+  sample time — the agent never sends its own clock.
+- **Reconnect**: exponential back-off (cap ~30s), retry forever; retries at
+  startup if the backend is not yet reachable.
+- **Revoked / invalid credential**: slow capped back-off (~5 min), retries
+  forever and logs the reason; self-heals when the credential is re-validated. No
+  tight loop, no exit.
+- **Partial failure**: a metric that cannot be read is skipped for that frame;
+  the rest of the sample is still sent.
+- **Shutdown**: `SIGINT`/`SIGTERM` closes the socket cleanly and exits 0.
+- **Invalid config**: exits non-zero with a clear message before any network
+  attempt.
+
+## Contract
+
+The wire frame is defined once in [`pkg/agentwire`](../../pkg/agentwire) and
+imported by both the agent and the backend ingestion handler, so they cannot
+drift. It carries a `schema_version` (currently `1`); the backend treats a frame
+without one as v1 for backward compatibility.

--- a/cmd/agent/agent_integration_test.go
+++ b/cmd/agent/agent_integration_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	v1 "github.com/denisakp/ogoune/internal/api/handler/v1"
+	"github.com/denisakp/ogoune/internal/api/middleware"
+	"github.com/denisakp/ogoune/internal/repository/fake"
+	"github.com/denisakp/ogoune/internal/service"
+	"github.com/denisakp/ogoune/pkg/agentwire"
+)
+
+// backendFixture stands up the REAL spec 079 ingestion path (HostCredentialAuth
+// + AgentStreamHandler over in-memory fakes) behind an httptest server.
+type backendFixture struct {
+	server     *httptest.Server
+	hostSvc    *service.HostService
+	metricsSvc *service.HostMetricsService
+}
+
+func newBackendFixture(t *testing.T) *backendFixture {
+	t.Helper()
+	credFake := fake.NewHostCredentialFake()
+	hostFake := fake.NewHostFake()
+	metricFake := fake.NewHostMetricFake()
+	resFake := fake.NewResourceFake()
+
+	credSvc := service.NewHostCredentialService(credFake)
+	hostSvc := service.NewHostService(hostFake, credSvc, metricFake, resFake, 45*time.Second)
+	metricsSvc := service.NewHostMetricsService(metricFake, hostFake, 48*time.Hour, 7*24*time.Hour)
+
+	r := chi.NewRouter()
+	r.With(middleware.HostCredentialAuth(credSvc)).
+		Get("/api/v1/agent/stream", v1.NewAgentStreamHandler(metricsSvc).Stream)
+
+	fx := &backendFixture{server: httptest.NewServer(r), hostSvc: hostSvc, metricsSvc: metricsSvc}
+	t.Cleanup(fx.server.Close)
+	return fx
+}
+
+func (fx *backendFixture) wsURL() string {
+	return "ws://" + fx.server.Listener.Addr().String() + "/api/v1/agent/stream"
+}
+
+// TestAgent_StreamsToRealBackend runs the real agent Streamer (real dial) against
+// the real 079 handler and asserts the host comes online with the pushed values
+// (SC-001, SC-008). A deterministic fake collector is injected so assertions are
+// exact.
+func TestAgent_StreamsToRealBackend(t *testing.T) {
+	fx := newBackendFixture(t)
+	ctx := context.Background()
+	host, raw, _, err := fx.hostSvc.Register(ctx, "web-1")
+	if err != nil {
+		t.Fatalf("register host: %v", err)
+	}
+
+	cfg := Config{BackendURL: fx.wsURL(), Credential: raw, Interval: time.Hour}
+	col := &fakeCollector{frame: agentwire.Frame{
+		OS: "Ubuntu 24.04", AgentVersion: "0.1.0",
+		CPUPct: 12.4, MemPct: 47.1, NetIn: 100, NetOut: 200,
+		Disks: []agentwire.DiskUsage{{Mount: "/", UsedPct: 23}},
+	}}
+	s := NewStreamer(cfg, col) // real dial + real clock
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() { _ = s.Run(runCtx) }()
+
+	waitFor(t, func() bool {
+		h, err := fx.hostSvc.Get(ctx, host.ID)
+		return err == nil && h.Online && h.LastCPUPct != nil && h.LastDiskPct != nil
+	}, "host should come online with metrics pushed by the real agent")
+	cancel()
+
+	h, err := fx.hostSvc.Get(ctx, host.ID)
+	if err != nil {
+		t.Fatalf("get host: %v", err)
+	}
+	if !h.Online {
+		t.Fatal("host not online")
+	}
+	if h.LastCPUPct == nil || *h.LastCPUPct < 12.39 || *h.LastCPUPct > 12.41 {
+		t.Fatalf("LastCPUPct = %v, want ~12.4", h.LastCPUPct)
+	}
+	if h.LastDiskPct == nil || *h.LastDiskPct < 22.9 || *h.LastDiskPct > 23.1 {
+		t.Fatalf("LastDiskPct = %v, want ~23", h.LastDiskPct)
+	}
+	if h.OS == nil || *h.OS != "Ubuntu 24.04" {
+		t.Fatalf("OS = %v, want Ubuntu 24.04", h.OS)
+	}
+
+	samples, err := fx.metricsSvc.History(ctx, host.ID, time.Time{}, time.Time{})
+	if err != nil || len(samples) == 0 {
+		t.Fatalf("expected a stored sample, got %d (err %v)", len(samples), err)
+	}
+}
+
+// TestAgent_RealDialRejectsBadCredential asserts the real dialer gets a 401 when
+// the credential is unknown/revoked (the auth boundary the agent then slow-backs
+// off on).
+func TestAgent_RealDialRejectsBadCredential(t *testing.T) {
+	fx := newBackendFixture(t)
+	cfg := Config{BackendURL: fx.wsURL(), Credential: "ag_live_notarealcredential", Interval: time.Hour}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, status, err := realDial(cfg)(ctx)
+	if err == nil {
+		t.Fatal("dial with bad credential should fail")
+	}
+	if status != 401 {
+		t.Fatalf("expected HTTP 401 on bad credential, got %d", status)
+	}
+}

--- a/cmd/agent/collector.go
+++ b/cmd/agent/collector.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/shirou/gopsutil/v4/cpu"
+	"github.com/shirou/gopsutil/v4/disk"
+	"github.com/shirou/gopsutil/v4/host"
+	"github.com/shirou/gopsutil/v4/mem"
+	"github.com/shirou/gopsutil/v4/net"
+
+	"github.com/denisakp/ogoune/pkg/agentwire"
+)
+
+// Collector produces one metrics frame per call. Behind an interface so the
+// stream loop can be unit-tested with a fake, keeping gopsutil off the test path.
+type Collector interface {
+	Collect(ctx context.Context) (agentwire.Frame, error)
+}
+
+// gopsutilCollector reads host metrics via gopsutil. A single failing metric is
+// logged and skipped (its field stays zero / the mount is omitted) rather than
+// failing the whole frame (FR-014).
+type gopsutilCollector struct {
+	agentVersion string
+}
+
+func newGopsutilCollector(agentVersion string) *gopsutilCollector {
+	return &gopsutilCollector{agentVersion: agentVersion}
+}
+
+func (c *gopsutilCollector) Collect(ctx context.Context) (agentwire.Frame, error) {
+	f := agentwire.Frame{AgentVersion: c.agentVersion}
+
+	if info, err := host.InfoWithContext(ctx); err != nil {
+		slog.Debug("collect: host info failed", "error", err)
+	} else {
+		f.OS = osLabel(info)
+	}
+
+	// CPU: percent since the previous call (≈ over the last interval).
+	if pcts, err := cpu.PercentWithContext(ctx, 0, false); err != nil || len(pcts) == 0 {
+		slog.Debug("collect: cpu failed", "error", err)
+	} else {
+		f.CPUPct = pcts[0]
+	}
+
+	if vm, err := mem.VirtualMemoryWithContext(ctx); err != nil {
+		slog.Debug("collect: mem failed", "error", err)
+	} else {
+		f.MemPct = vm.UsedPercent
+	}
+
+	if counters, err := net.IOCountersWithContext(ctx, false); err != nil || len(counters) == 0 {
+		slog.Debug("collect: net failed", "error", err)
+	} else {
+		f.NetIn = int64(counters[0].BytesRecv)
+		f.NetOut = int64(counters[0].BytesSent)
+	}
+
+	f.Disks = collectDisks(ctx)
+
+	return f, nil
+}
+
+// collectDisks returns per-physical-mount usage, skipping mounts that error.
+func collectDisks(ctx context.Context) []agentwire.DiskUsage {
+	parts, err := disk.PartitionsWithContext(ctx, false)
+	if err != nil {
+		slog.Debug("collect: disk partitions failed", "error", err)
+		return nil
+	}
+	var out []agentwire.DiskUsage
+	for _, p := range parts {
+		u, err := disk.UsageWithContext(ctx, p.Mountpoint)
+		if err != nil {
+			slog.Debug("collect: disk usage failed", "mount", p.Mountpoint, "error", err)
+			continue
+		}
+		out = append(out, agentwire.DiskUsage{Mount: p.Mountpoint, UsedPct: u.UsedPercent})
+	}
+	return out
+}
+
+func osLabel(info *host.InfoStat) string {
+	if info.Platform == "" {
+		return info.OS
+	}
+	if info.PlatformVersion == "" {
+		return info.Platform
+	}
+	return fmt.Sprintf("%s %s", info.Platform, info.PlatformVersion)
+}

--- a/cmd/agent/collector_test.go
+++ b/cmd/agent/collector_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/denisakp/ogoune/pkg/agentwire"
+)
+
+// fakeCollector returns a fixed frame; used by the stream tests.
+type fakeCollector struct {
+	frame agentwire.Frame
+	err   error
+	calls int
+}
+
+func (f *fakeCollector) Collect(context.Context) (agentwire.Frame, error) {
+	f.calls++
+	return f.frame, f.err
+}
+
+// TestGopsutilCollector_Smoke verifies the real collector returns finite,
+// in-range values on this host. CPU % on the first call may be ~0 (delta since
+// process start), so it is only checked for finiteness/non-negativity.
+func TestGopsutilCollector_Smoke(t *testing.T) {
+	c := newGopsutilCollector("test-0.0.0")
+	f, err := c.Collect(context.Background())
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if f.AgentVersion != "test-0.0.0" {
+		t.Errorf("AgentVersion = %q", f.AgentVersion)
+	}
+	if math.IsNaN(f.CPUPct) || math.IsInf(f.CPUPct, 0) || f.CPUPct < 0 {
+		t.Errorf("CPUPct not finite/non-negative: %v", f.CPUPct)
+	}
+	if f.MemPct < 0 || f.MemPct > 100 {
+		t.Errorf("MemPct out of range: %v", f.MemPct)
+	}
+	if f.NetIn < 0 || f.NetOut < 0 {
+		t.Errorf("net counters negative: in=%d out=%d", f.NetIn, f.NetOut)
+	}
+	for _, d := range f.Disks {
+		if d.UsedPct < 0 || d.UsedPct > 100 {
+			t.Errorf("disk %q used_pct out of range: %v", d.Mount, d.UsedPct)
+		}
+	}
+	// The frame must satisfy the shared contract's validation.
+	if err := f.Validate(); err != nil {
+		t.Errorf("collected frame fails agentwire.Validate: %v", err)
+	}
+}

--- a/cmd/agent/config.go
+++ b/cmd/agent/config.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	defaultConfigPath = "/etc/ogoune-agent.yaml"
+	defaultInterval   = 10 * time.Second
+	defaultLogLevel   = "info"
+	credentialPrefix  = "ag_live_"
+)
+
+// Config is the resolved agent configuration. Precedence: flags > env > file >
+// defaults.
+type Config struct {
+	BackendURL         string        `yaml:"backend_url"`
+	Credential         string        `yaml:"credential"`
+	Interval           time.Duration `yaml:"interval"`
+	LogLevel           string        `yaml:"log_level"`
+	InsecureSkipVerify bool          `yaml:"insecure_skip_verify"`
+}
+
+// Load resolves configuration from (in increasing precedence) defaults, a YAML
+// file, environment variables, and command-line flags. getenv and readFile are
+// injected for testability. A missing config file is not an error when the
+// required values are supplied by env/flags.
+func Load(args []string, getenv func(string) string, readFile func(string) ([]byte, error)) (Config, error) {
+	cfg := Config{Interval: defaultInterval, LogLevel: defaultLogLevel}
+
+	// Resolve config file path (flag/env override the default) with a pre-parse.
+	configPath := defaultConfigPath
+	if v := getenv("OGOUNE_CONFIG"); v != "" {
+		configPath = v
+	}
+	pre := flag.NewFlagSet("pre", flag.ContinueOnError)
+	pre.SetOutput(io.Discard)
+	preConfig := pre.String("config", "", "path to config file")
+	_ = pre.Parse(args)
+	if *preConfig != "" {
+		configPath = *preConfig
+	}
+
+	// 1) File (optional).
+	if b, err := readFile(configPath); err == nil {
+		if err := yaml.Unmarshal(b, &cfg); err != nil {
+			return Config{}, fmt.Errorf("parse config %s: %w", configPath, err)
+		}
+	}
+
+	// 2) Environment.
+	if v := getenv("OGOUNE_BACKEND_URL"); v != "" {
+		cfg.BackendURL = v
+	}
+	if v := getenv("OGOUNE_CREDENTIAL"); v != "" {
+		cfg.Credential = v
+	}
+	if v := getenv("OGOUNE_INTERVAL"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return Config{}, fmt.Errorf("invalid OGOUNE_INTERVAL %q: %w", v, err)
+		}
+		cfg.Interval = d
+	}
+	if v := getenv("OGOUNE_LOG_LEVEL"); v != "" {
+		cfg.LogLevel = v
+	}
+	if v := getenv("OGOUNE_INSECURE"); v == "true" || v == "1" {
+		cfg.InsecureSkipVerify = true
+	}
+
+	// 3) Flags (highest precedence; only override when explicitly set).
+	fs := flag.NewFlagSet("ogoune-agent", flag.ContinueOnError)
+	backendURL := fs.String("backend-url", "", "backend WebSocket URL (wss://host/api/v1/agent/stream)")
+	credential := fs.String("credential", "", "host agent credential (ag_live_…)")
+	interval := fs.Duration("interval", 0, "sample interval (e.g. 10s)")
+	logLevel := fs.String("log-level", "", "log level (debug|info|warn|error)")
+	insecure := fs.Bool("insecure", false, "skip TLS verification (dev only)")
+	fs.String("config", "", "path to config file (default "+defaultConfigPath+")")
+	if err := fs.Parse(args); err != nil {
+		return Config{}, err
+	}
+	fs.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "backend-url":
+			cfg.BackendURL = *backendURL
+		case "credential":
+			cfg.Credential = *credential
+		case "interval":
+			cfg.Interval = *interval
+		case "log-level":
+			cfg.LogLevel = *logLevel
+		case "insecure":
+			cfg.InsecureSkipVerify = *insecure
+		}
+	})
+
+	if err := cfg.Validate(); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+// Validate checks the resolved configuration.
+func (c Config) Validate() error {
+	if strings.TrimSpace(c.BackendURL) == "" {
+		return fmt.Errorf("backend_url is required")
+	}
+	u, err := url.Parse(c.BackendURL)
+	if err != nil || (u.Scheme != "ws" && u.Scheme != "wss") || u.Host == "" {
+		return fmt.Errorf("backend_url must be a ws:// or wss:// URL, got %q", c.BackendURL)
+	}
+	if !strings.HasPrefix(c.Credential, credentialPrefix) {
+		return fmt.Errorf("credential is required and must start with %q", credentialPrefix)
+	}
+	if c.Interval < time.Second {
+		return fmt.Errorf("interval must be at least 1s, got %s", c.Interval)
+	}
+	return nil
+}

--- a/cmd/agent/config_test.go
+++ b/cmd/agent/config_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+func noEnv(string) string { return "" }
+
+func envFrom(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+func noFile(string) ([]byte, error) { return nil, os.ErrNotExist }
+
+func fileFrom(content string) func(string) ([]byte, error) {
+	return func(string) ([]byte, error) { return []byte(content), nil }
+}
+
+func TestLoad_FlagsOverEnvOverFile(t *testing.T) {
+	file := "backend_url: wss://file/api/v1/agent/stream\ncredential: ag_live_file\ninterval: 30s\n"
+	env := map[string]string{
+		"OGOUNE_CREDENTIAL": "ag_live_env",
+		"OGOUNE_INTERVAL":   "20s",
+	}
+	args := []string{"--credential", "ag_live_flag", "--interval", "15s"}
+
+	cfg, err := Load(args, envFrom(env), fileFrom(file))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// backend_url only in file → file wins (no env/flag override).
+	if cfg.BackendURL != "wss://file/api/v1/agent/stream" {
+		t.Errorf("BackendURL = %q, want file value", cfg.BackendURL)
+	}
+	// credential: flag > env > file.
+	if cfg.Credential != "ag_live_flag" {
+		t.Errorf("Credential = %q, want ag_live_flag (flag wins)", cfg.Credential)
+	}
+	// interval: flag wins.
+	if cfg.Interval != 15*time.Second {
+		t.Errorf("Interval = %s, want 15s (flag wins)", cfg.Interval)
+	}
+}
+
+func TestLoad_EnvOverFile(t *testing.T) {
+	file := "backend_url: wss://file/api/v1/agent/stream\ncredential: ag_live_file\n"
+	env := map[string]string{"OGOUNE_CREDENTIAL": "ag_live_env"}
+	cfg, err := Load(nil, envFrom(env), fileFrom(file))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Credential != "ag_live_env" {
+		t.Errorf("Credential = %q, want env value", cfg.Credential)
+	}
+}
+
+func TestLoad_Defaults(t *testing.T) {
+	cfg, err := Load(
+		[]string{"--backend-url", "wss://h/api/v1/agent/stream", "--credential", "ag_live_x"},
+		noEnv, noFile,
+	)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Interval != defaultInterval {
+		t.Errorf("Interval = %s, want default %s", cfg.Interval, defaultInterval)
+	}
+	if cfg.LogLevel != defaultLogLevel {
+		t.Errorf("LogLevel = %q, want %q", cfg.LogLevel, defaultLogLevel)
+	}
+}
+
+func TestLoad_MissingRequired(t *testing.T) {
+	// No backend_url anywhere.
+	if _, err := Load([]string{"--credential", "ag_live_x"}, noEnv, noFile); err == nil {
+		t.Error("expected error when backend_url missing")
+	}
+	// No credential anywhere.
+	if _, err := Load([]string{"--backend-url", "wss://h/api/v1/agent/stream"}, noEnv, noFile); err == nil {
+		t.Error("expected error when credential missing")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	base := Config{BackendURL: "wss://h/api/v1/agent/stream", Credential: "ag_live_x", Interval: 10 * time.Second}
+	if err := base.Validate(); err != nil {
+		t.Fatalf("valid config rejected: %v", err)
+	}
+
+	bad := base
+	bad.BackendURL = "http://h" // not ws/wss
+	if err := bad.Validate(); err == nil {
+		t.Error("non-ws backend_url should be rejected")
+	}
+
+	bad = base
+	bad.Credential = "pk_live_x" // wrong prefix
+	if err := bad.Validate(); err == nil {
+		t.Error("non-ag_live credential should be rejected")
+	}
+
+	bad = base
+	bad.Interval = 500 * time.Millisecond
+	if err := bad.Validate(); err == nil {
+		t.Error("sub-second interval should be rejected")
+	}
+}
+
+func TestLoad_InvalidEnvInterval(t *testing.T) {
+	env := map[string]string{"OGOUNE_INTERVAL": "not-a-duration"}
+	_, err := Load(
+		[]string{"--backend-url", "wss://h/api/v1/agent/stream", "--credential", "ag_live_x"},
+		envFrom(env), noFile,
+	)
+	if err == nil {
+		t.Error("invalid OGOUNE_INTERVAL should error")
+	}
+	_ = errors.Unwrap(err)
+}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -1,0 +1,56 @@
+// Command ogoune-agent is the host monitoring agent (spec 080). It collects
+// system metrics and streams them to the Ogoune backend over the
+// /api/v1/agent/stream WebSocket, authenticated by a per-host ag_live_
+// credential. The agent is optional and fail-safe: it never crashes the host,
+// retries on failure, and slows to a capped back-off on a revoked credential.
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// version is the agent version reported in each frame. Overridable at build time
+// via -ldflags "-X main.version=…".
+var version = "0.1.0"
+
+func main() {
+	cfg, err := Load(os.Args[1:], os.Getenv, os.ReadFile)
+	if err != nil {
+		// Fail fast, before any network attempt, with a clear message.
+		slog.Error("ogoune-agent: invalid configuration", "error", err)
+		os.Exit(2)
+	}
+
+	setupLogging(cfg.LogLevel)
+	slog.Info("ogoune-agent starting", "version", version, "backend", cfg.BackendURL, "interval", cfg.Interval.String())
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	streamer := NewStreamer(cfg, newGopsutilCollector(version))
+	if err := streamer.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		slog.Error("ogoune-agent stopped", "error", err)
+		os.Exit(1)
+	}
+	slog.Info("ogoune-agent stopped cleanly")
+}
+
+func setupLogging(level string) {
+	var lvl slog.Level
+	switch level {
+	case "debug":
+		lvl = slog.LevelDebug
+	case "warn":
+		lvl = slog.LevelWarn
+	case "error":
+		lvl = slog.LevelError
+	default:
+		lvl = slog.LevelInfo
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: lvl})))
+}

--- a/cmd/agent/stream.go
+++ b/cmd/agent/stream.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/denisakp/ogoune/pkg/agentwire"
+)
+
+// wsConn is the minimal socket surface the streamer needs, so tests can supply a
+// fake without a real network.
+type wsConn interface {
+	Write(ctx context.Context, data []byte) error
+	Close(code websocket.StatusCode, reason string) error
+}
+
+// dialFunc establishes a connection, returning the HTTP status of the upgrade
+// attempt (used to distinguish a 401 auth rejection from a transient failure).
+type dialFunc func(ctx context.Context) (wsConn, int, error)
+
+// Streamer owns the resilient send loop: connect, stream one frame per interval,
+// and reconnect with back-off. A permanent 401 uses a slow capped back-off
+// (retrying forever so it self-heals on re-validation); transient failures use a
+// fast capped back-off.
+type Streamer struct {
+	cfg       Config
+	collector Collector
+	dial      dialFunc
+	sleep     func(ctx context.Context, d time.Duration) bool
+	transient backoff
+	auth      backoff
+}
+
+// NewStreamer wires the production dialer and clock.
+func NewStreamer(cfg Config, collector Collector) *Streamer {
+	return &Streamer{
+		cfg:       cfg,
+		collector: collector,
+		dial:      realDial(cfg),
+		sleep:     sleepCtx,
+		transient: backoff{base: 1 * time.Second, max: 30 * time.Second},
+		auth:      backoff{base: 30 * time.Second, max: 5 * time.Minute},
+	}
+}
+
+// Run connects and streams until ctx is cancelled, reconnecting on failure. It
+// only returns when ctx is done.
+func (s *Streamer) Run(ctx context.Context) error {
+	for {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		conn, status, err := s.dial(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			var d time.Duration
+			if status == http.StatusUnauthorized {
+				d = s.auth.next()
+				slog.Warn("agent: credential rejected — backing off (will self-heal if re-validated)", "retry_in", d.String(), "status", status)
+			} else {
+				d = s.transient.next()
+				slog.Warn("agent: connect failed — retrying", "retry_in", d.String(), "error", err)
+			}
+			if !s.sleep(ctx, d) {
+				return ctx.Err()
+			}
+			continue
+		}
+		// Connected: reset both regimes.
+		s.transient.reset()
+		s.auth.reset()
+		slog.Info("agent: connected", "url", s.cfg.BackendURL)
+
+		streamErr := s.streamLoop(ctx, conn)
+		_ = conn.Close(websocket.StatusNormalClosure, "")
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		d := s.transient.next()
+		slog.Warn("agent: stream ended — reconnecting", "retry_in", d.String(), "error", streamErr)
+		if !s.sleep(ctx, d) {
+			return ctx.Err()
+		}
+	}
+}
+
+// streamLoop sends one frame immediately, then one per interval, until an error
+// or ctx cancellation.
+func (s *Streamer) streamLoop(ctx context.Context, conn wsConn) error {
+	send := func() error {
+		frame, err := s.collector.Collect(ctx)
+		if err != nil {
+			return err
+		}
+		b, err := agentwire.Encode(frame)
+		if err != nil {
+			return err
+		}
+		return conn.Write(ctx, b)
+	}
+
+	if err := send(); err != nil {
+		return err
+	}
+	ticker := time.NewTicker(s.cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := send(); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// backoff is an exponential back-off with a cap. next() returns the current
+// delay and advances; reset() returns to the base delay.
+type backoff struct {
+	base, max, cur time.Duration
+}
+
+func (b *backoff) next() time.Duration {
+	d := b.cur
+	if d == 0 {
+		d = b.base
+	}
+	nx := d * 2
+	if nx > b.max {
+		nx = b.max
+	}
+	b.cur = nx
+	return d
+}
+
+func (b *backoff) reset() { b.cur = 0 }
+
+// sleepCtx sleeps for d, returning false if ctx is cancelled first.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+// realDial dials the backend with the host bearer credential.
+func realDial(cfg Config) dialFunc {
+	var httpClient *http.Client
+	if cfg.InsecureSkipVerify {
+		httpClient = &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}} //nolint:gosec // opt-in dev flag
+	}
+	return func(ctx context.Context) (wsConn, int, error) {
+		opts := &websocket.DialOptions{
+			HTTPHeader: http.Header{"Authorization": []string{"Bearer " + cfg.Credential}},
+		}
+		if httpClient != nil {
+			opts.HTTPClient = httpClient
+		}
+		c, resp, err := websocket.Dial(ctx, cfg.BackendURL, opts)
+		status := 0
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		if err != nil {
+			return nil, status, err
+		}
+		return &coderConn{c: c}, status, nil
+	}
+}
+
+type coderConn struct{ c *websocket.Conn }
+
+func (w *coderConn) Write(ctx context.Context, data []byte) error {
+	return w.c.Write(ctx, websocket.MessageText, data)
+}
+
+func (w *coderConn) Close(code websocket.StatusCode, reason string) error {
+	return w.c.Close(code, reason)
+}

--- a/cmd/agent/stream_test.go
+++ b/cmd/agent/stream_test.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/denisakp/ogoune/pkg/agentwire"
+)
+
+// fakeConn captures frames written to it.
+type fakeConn struct {
+	mu     sync.Mutex
+	frames [][]byte
+}
+
+func (c *fakeConn) Write(_ context.Context, data []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.frames = append(c.frames, append([]byte(nil), data...))
+	return nil
+}
+
+func (c *fakeConn) Close(websocket.StatusCode, string) error { return nil }
+
+func (c *fakeConn) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.frames)
+}
+
+func (c *fakeConn) last() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.frames) == 0 {
+		return nil
+	}
+	return c.frames[len(c.frames)-1]
+}
+
+func newTestStreamer(cfg Config, collector Collector, dial dialFunc, sleep func(context.Context, time.Duration) bool) *Streamer {
+	return &Streamer{
+		cfg:       cfg,
+		collector: collector,
+		dial:      dial,
+		sleep:     sleep,
+		transient: backoff{base: 1 * time.Second, max: 30 * time.Second},
+		auth:      backoff{base: 30 * time.Second, max: 5 * time.Minute},
+	}
+}
+
+func testCfg() Config {
+	return Config{BackendURL: "wss://h/api/v1/agent/stream", Credential: "ag_live_x", Interval: time.Hour}
+}
+
+// TestStreamer_SendsFrame covers the send path: collect → encode → write. The
+// interval is huge so only the immediate send fires before we cancel.
+func TestStreamer_SendsFrame(t *testing.T) {
+	conn := &fakeConn{}
+	col := &fakeCollector{frame: agentwire.Frame{CPUPct: 12.4, MemPct: 47.1, NetIn: 1, NetOut: 2, Disks: []agentwire.DiskUsage{{Mount: "/", UsedPct: 23}}}}
+	dial := func(context.Context) (wsConn, int, error) { return conn, 101, nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := newTestStreamer(testCfg(), col, dial, func(context.Context, time.Duration) bool { return true })
+
+	go func() { _ = s.Run(ctx) }()
+
+	waitFor(t, func() bool { return conn.count() >= 1 }, "frame should be sent after connect")
+	cancel()
+
+	f, err := agentwire.Decode(conn.last())
+	if err != nil {
+		t.Fatalf("decode sent frame: %v", err)
+	}
+	if f.CPUPct != 12.4 || f.Disks[0].UsedPct != 23 {
+		t.Fatalf("sent frame mismatch: %+v", f)
+	}
+	if f.SchemaVersion != agentwire.SchemaVersion {
+		t.Fatalf("sent frame not version-stamped: %d", f.SchemaVersion)
+	}
+}
+
+// TestStreamer_TransientBackoff asserts a failing (non-auth) dial retries with
+// the fast exponential regime (1s, 2s, 4s …).
+func TestStreamer_TransientBackoff(t *testing.T) {
+	dialErr := errors.New("connection refused")
+	dial := func(context.Context) (wsConn, int, error) { return nil, 0, dialErr }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var mu sync.Mutex
+	var sleeps []time.Duration
+	sleep := func(_ context.Context, d time.Duration) bool {
+		mu.Lock()
+		sleeps = append(sleeps, d)
+		n := len(sleeps)
+		mu.Unlock()
+		if n >= 3 {
+			cancel()
+			return false
+		}
+		return true
+	}
+	s := newTestStreamer(testCfg(), &fakeCollector{}, dial, sleep)
+	_ = s.Run(ctx)
+
+	want := []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(sleeps) < 3 {
+		t.Fatalf("expected ≥3 backoffs, got %v", sleeps)
+	}
+	for i, w := range want {
+		if sleeps[i] != w {
+			t.Errorf("transient backoff[%d] = %s, want %s (seq %v)", i, sleeps[i], w, sleeps)
+		}
+	}
+}
+
+// TestStreamer_StartupRetry: backend unreachable at startup ⇒ retry, not exit.
+func TestStreamer_StartupRetry(t *testing.T) {
+	var calls int
+	var mu sync.Mutex
+	conn := &fakeConn{}
+	dial := func(context.Context) (wsConn, int, error) {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+		if n < 3 {
+			return nil, 0, errors.New("dial: no route to host")
+		}
+		return conn, 101, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := newTestStreamer(testCfg(), &fakeCollector{frame: agentwire.Frame{CPUPct: 1, MemPct: 2}}, dial, instantSleep)
+	go func() { _ = s.Run(ctx) }()
+
+	waitFor(t, func() bool { return conn.count() >= 1 }, "agent should connect after startup retries, not exit")
+	cancel()
+}
+
+// TestStreamer_AuthRejectionSlowBackoffAndSelfHeal asserts a persistent 401 uses
+// the slow capped regime (30s, 60s, 120s …), never exits, and self-heals once
+// the credential is re-validated (dial later succeeds).
+func TestStreamer_AuthRejectionSlowBackoffAndSelfHeal(t *testing.T) {
+	var mu sync.Mutex
+	var calls int
+	var sleeps []time.Duration
+	conn := &fakeConn{}
+	dial := func(context.Context) (wsConn, int, error) {
+		mu.Lock()
+		calls++
+		n := calls
+		mu.Unlock()
+		if n <= 3 {
+			return nil, 401, errors.New("expected handshake status 401")
+		}
+		return conn, 101, nil // credential re-validated
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sleep := func(_ context.Context, d time.Duration) bool {
+		mu.Lock()
+		sleeps = append(sleeps, d)
+		mu.Unlock()
+		return true // never cancel via sleep; the test cancels after self-heal
+	}
+	s := newTestStreamer(testCfg(), &fakeCollector{frame: agentwire.Frame{CPUPct: 1, MemPct: 2}}, dial, sleep)
+	go func() { _ = s.Run(ctx) }()
+
+	waitFor(t, func() bool { return conn.count() >= 1 }, "agent should self-heal and stream after credential re-validation")
+	cancel()
+
+	mu.Lock()
+	defer mu.Unlock()
+	// First three backoffs are the slow auth regime, not the 1s transient one.
+	want := []time.Duration{30 * time.Second, 60 * time.Second, 120 * time.Second}
+	if len(sleeps) < 3 {
+		t.Fatalf("expected ≥3 auth backoffs, got %v", sleeps)
+	}
+	for i, w := range want {
+		if sleeps[i] != w {
+			t.Errorf("auth backoff[%d] = %s, want %s (seq %v)", i, sleeps[i], w, sleeps)
+		}
+	}
+}
+
+func TestBackoff_Sequence(t *testing.T) {
+	b := backoff{base: time.Second, max: 8 * time.Second}
+	got := []time.Duration{b.next(), b.next(), b.next(), b.next(), b.next()}
+	want := []time.Duration{1, 2, 4, 8, 8}
+	for i := range want {
+		if got[i] != want[i]*time.Second {
+			t.Errorf("next[%d] = %s, want %ds (%v)", i, got[i], want[i], got)
+		}
+	}
+	b.reset()
+	if b.next() != time.Second {
+		t.Errorf("after reset, next = %s, want 1s", b.next())
+	}
+}
+
+func instantSleep(context.Context, time.Duration) bool { return true }
+
+func waitFor(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting: %s", msg)
+}

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/pquerna/otp v1.5.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.1
+	github.com/shirou/gopsutil/v4 v4.26.6
 	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/http-swagger v1.3.4
 	github.com/swaggo/swag/v2 v2.0.0-rc5
@@ -81,7 +82,6 @@ require (
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/shirou/gopsutil/v4 v4.26.3 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/sv-tools/openapi v0.4.0 // indirect
 	github.com/swaggo/files v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/shirou/gopsutil/v4 v4.26.3 h1:2ESdQt90yU3oXF/CdOlRCJxrP+Am1aBYubTMTfxJ1qc=
-github.com/shirou/gopsutil/v4 v4.26.3/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
+github.com/shirou/gopsutil/v4 v4.26.6 h1:Mzr/npDtQC/xpeEuQKHZt8Zo9CmPvhTj8nkR8w5TLDs=
+github.com/shirou/gopsutil/v4 v4.26.6/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/spf13/cast v1.7.0 h1:ntdiHjuueXFgm5nzDRdOS4yfT43P5Fnud6DH50rz/7w=

--- a/internal/api/handler/v1/agent_stream_handler.go
+++ b/internal/api/handler/v1/agent_stream_handler.go
@@ -5,35 +5,25 @@ import (
 	"net/http"
 
 	"github.com/coder/websocket"
-	"github.com/coder/websocket/wsjson"
 
 	"github.com/denisakp/ogoune/internal/api/middleware"
 	"github.com/denisakp/ogoune/internal/domain"
 	"github.com/denisakp/ogoune/internal/service"
+	"github.com/denisakp/ogoune/pkg/agentwire"
 )
 
 // AgentStreamHandler upgrades the agent ingestion route to a WebSocket and
-// reads periodic JSON metric frames, delegating validation + persistence to
+// reads periodic metric frames, delegating validation + persistence to
 // HostMetricsService.Ingest. The socket is kept off the unit-test path by
-// keeping all logic in the service; this handler is a thin read-loop.
+// keeping all logic in the service; this handler is a thin read-loop. Frames
+// are decoded through the shared pkg/agentwire contract so the agent and the
+// backend cannot drift.
 type AgentStreamHandler struct {
 	metrics *service.HostMetricsService
 }
 
 func NewAgentStreamHandler(metrics *service.HostMetricsService) *AgentStreamHandler {
 	return &AgentStreamHandler{metrics: metrics}
-}
-
-// agentFrame is the wire frame. Required numeric fields are pointers so an
-// absent field (malformed frame) is distinguishable from a zero value.
-type agentFrame struct {
-	OS           *string            `json:"os"`
-	AgentVersion *string            `json:"agent_version"`
-	CPUPct       *float64           `json:"cpu_pct"`
-	MemPct       *float64           `json:"mem_pct"`
-	NetIn        *int64             `json:"net_in"`
-	NetOut       *int64             `json:"net_out"`
-	Disks        []domain.DiskUsage `json:"disks"`
 }
 
 // Stream handles GET /api/v1/agent/stream (WebSocket upgrade, host-credential auth).
@@ -55,29 +45,46 @@ func (h *AgentStreamHandler) Stream(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	for {
-		var f agentFrame
-		if err := wsjson.Read(ctx, conn, &f); err != nil {
+		_, data, err := conn.Read(ctx)
+		if err != nil {
 			// Client disconnected or context cancelled — end the read loop.
 			break
 		}
-		if f.CPUPct == nil || f.MemPct == nil || f.NetIn == nil || f.NetOut == nil {
-			// Malformed frame — do not store, do not advance last_seen.
-			slog.Debug("agent stream: malformed frame", "host_id", hostID)
+		frame, err := agentwire.Decode(data)
+		if err != nil {
+			// Malformed / missing-field / unsupported-version frame — do not
+			// store, do not advance last_seen.
+			slog.Debug("agent stream: rejected frame", "host_id", hostID, "error", err)
 			continue
 		}
-		sample := service.IngestSample{
-			OS:           f.OS,
-			AgentVersion: f.AgentVersion,
-			CPUPct:       *f.CPUPct,
-			MemPct:       *f.MemPct,
-			NetIn:        *f.NetIn,
-			NetOut:       *f.NetOut,
-			Disks:        f.Disks,
-		}
-		if err := h.metrics.Ingest(ctx, hostID, sample); err != nil {
+		if err := h.metrics.Ingest(ctx, hostID, frameToSample(frame)); err != nil {
 			slog.Warn("agent stream: ingest failed", "host_id", hostID, "error", err)
 			// Keep the connection open; a transient bad frame must not drop the agent.
 		}
 	}
 	conn.Close(websocket.StatusNormalClosure, "")
+}
+
+// frameToSample maps the shared wire frame to the ingestion sample. Optional
+// string fields become nil pointers when empty so the host snapshot's
+// COALESCE keeps prior values.
+func frameToSample(f agentwire.Frame) service.IngestSample {
+	s := service.IngestSample{
+		CPUPct: f.CPUPct,
+		MemPct: f.MemPct,
+		NetIn:  f.NetIn,
+		NetOut: f.NetOut,
+	}
+	if f.OS != "" {
+		os := f.OS
+		s.OS = &os
+	}
+	if f.AgentVersion != "" {
+		av := f.AgentVersion
+		s.AgentVersion = &av
+	}
+	for _, d := range f.Disks {
+		s.Disks = append(s.Disks, domain.DiskUsage{Mount: d.Mount, UsedPct: d.UsedPct})
+	}
+	return s
 }

--- a/internal/api/handler/v1/agent_stream_test.go
+++ b/internal/api/handler/v1/agent_stream_test.go
@@ -111,3 +111,50 @@ func TestAgentStream_RejectsBadCredential(t *testing.T) {
 	}
 	require.Error(t, err2, "dial without a credential must not establish the stream")
 }
+
+// TestAgentStream_VersionedAndLegacyFrames asserts the backend accepts BOTH a
+// frame carrying schema_version:1 and a legacy frame with no schema_version
+// (spec 080 additive contract; 079 backward-compat regression).
+func TestAgentStream_VersionedAndLegacyFrames(t *testing.T) {
+	cases := []struct {
+		name  string
+		frame map[string]any
+	}{
+		{"versioned", map[string]any{
+			"schema_version": 1,
+			"cpu_pct":        33.0, "mem_pct": 44.0, "net_in": 1, "net_out": 2,
+			"disks": []any{map[string]any{"mount": "/", "used_pct": 55.0}},
+		}},
+		{"legacy_no_version", map[string]any{
+			"cpu_pct": 33.0, "mem_pct": 44.0, "net_in": 1, "net_out": 2,
+			"disks": []any{map[string]any{"mount": "/", "used_pct": 55.0}},
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			deps := newHostTestDeps()
+			ctx := context.Background()
+			host, raw, _, err := deps.hostSvc.Register(ctx, "h")
+			require.NoError(t, err)
+
+			r := chi.NewRouter()
+			r.With(middleware.HostCredentialAuth(deps.credSvc)).
+				Get("/api/v1/agent/stream", v1.NewAgentStreamHandler(deps.metricsSvc).Stream)
+			server := httptest.NewServer(r)
+			defer server.Close()
+
+			dialCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			conn, _, err := websocket.Dial(dialCtx, "ws://"+server.Listener.Addr().String()+"/api/v1/agent/stream",
+				&websocket.DialOptions{HTTPHeader: http.Header{"Authorization": []string{"Bearer " + raw}}})
+			require.NoError(t, err)
+			require.NoError(t, wsjson.Write(dialCtx, conn, tc.frame))
+			_ = conn.Close(websocket.StatusNormalClosure, "")
+
+			require.Eventually(t, func() bool {
+				h, err := deps.hostSvc.Get(ctx, host.ID)
+				return err == nil && h.Online && h.LastCPUPct != nil
+			}, 2*time.Second, 20*time.Millisecond, "host should ingest the %s frame", tc.name)
+		})
+	}
+}

--- a/nebula/.vitepress/config.ts
+++ b/nebula/.vitepress/config.ts
@@ -60,6 +60,7 @@ export default defineConfig({
             { text: 'Community (SQLite)', link: '/self-host/community' },
             { text: 'Production (Postgres + Redis)', link: '/self-host/production' },
             { text: 'Configuration', link: '/self-host/configuration' },
+            { text: 'Host agent', link: '/self-host/agent' },
           ],
         },
       ],

--- a/nebula/self-host/agent.md
+++ b/nebula/self-host/agent.md
@@ -1,0 +1,66 @@
+# Host agent
+
+The **host agent** (`ogoune-agent`) is an optional Go binary you install on a
+monitored Linux server. It collects system metrics — OS, CPU, memory, per-mount
+disk, and network — and streams them to Ogoune every ~10 seconds, so a host's
+health shows up alongside your uptime monitors.
+
+The agent is **optional**: nothing in Ogoune's monitoring depends on it. It is
+also **fail-safe** — it never destabilises the host, retries through outages, and
+slows down (rather than hammering) when a credential is revoked.
+
+## 1. Register the host
+
+From Ogoune (operator API key), register the host to get a one-time credential:
+
+```bash
+curl -sS -X POST https://your-ogoune/api/v1/hosts \
+  -H "Authorization: Bearer <operator-api-key>" \
+  -H "Content-Type: application/json" -d '{"name":"web-1"}'
+# → { "data": { "host": {...}, "credential": "ag_live_…" } }
+```
+
+Copy the `credential` — it is shown **once**.
+
+## 2. Install and run
+
+```bash
+make build-agent   # → dist/ogoune-agent
+
+sudo install -m755 dist/ogoune-agent /usr/local/bin/ogoune-agent
+sudo install -m600 packaging/agent/ogoune-agent.example.yaml /etc/ogoune-agent.yaml
+# edit /etc/ogoune-agent.yaml: set backend_url + credential
+sudo install -m644 packaging/agent/ogoune-agent.service /etc/systemd/system/
+sudo systemctl daemon-reload && sudo systemctl enable --now ogoune-agent
+journalctl -u ogoune-agent -f
+```
+
+Within ~15 seconds the host reports live metrics and shows as **online**.
+
+## Configuration
+
+Precedence: **flags > environment > file > defaults**.
+
+| Setting | File key | Env | Flag | Default |
+|---|---|---|---|---|
+| Backend URL | `backend_url` | `OGOUNE_BACKEND_URL` | `--backend-url` | — (required) |
+| Credential | `credential` | `OGOUNE_CREDENTIAL` | `--credential` | — (required) |
+| Interval | `interval` | `OGOUNE_INTERVAL` | `--interval` | `10s` |
+| Log level | `log_level` | `OGOUNE_LOG_LEVEL` | `--log-level` | `info` |
+| Skip TLS verify | `insecure_skip_verify` | `OGOUNE_INSECURE` | `--insecure` | `false` |
+
+## Behaviour
+
+- **Reconnect**: exponential back-off (cap ~30s), retries forever; also retries at
+  startup if the backend is not yet reachable.
+- **Revoked credential**: slows to a capped (~5 min) back-off, retries forever and
+  logs the reason; resumes automatically once you re-issue and update the
+  credential.
+- **Rotation**: issue a new credential in Ogoune, update the config, restart the
+  service.
+- **Shutdown**: `systemctl stop` closes the connection cleanly.
+
+## Scope
+
+Linux only for now. Windows/macOS agents, a Hosts UI, and kernel-level (eBPF)
+capture are planned separately.

--- a/packaging/agent/ogoune-agent.example.yaml
+++ b/packaging/agent/ogoune-agent.example.yaml
@@ -1,0 +1,24 @@
+# Ogoune host agent — configuration (spec 080)
+# Install to /etc/ogoune-agent.yaml (mode 0600 — it contains a secret).
+# Precedence: command-line flags > environment variables > this file > defaults.
+
+# Backend WebSocket URL (REQUIRED). Point at the /api/v1/agent/stream route.
+#   env: OGOUNE_BACKEND_URL   flag: --backend-url
+backend_url: wss://ogoune.example.com/api/v1/agent/stream
+
+# Per-host agent credential (REQUIRED). Shown once when you register the host
+# (POST /api/v1/hosts). Starts with "ag_live_".
+#   env: OGOUNE_CREDENTIAL    flag: --credential
+credential: ag_live_replace_me
+
+# Sample interval (optional, default 10s). Go duration syntax.
+#   env: OGOUNE_INTERVAL      flag: --interval
+interval: 10s
+
+# Log level: debug | info | warn | error (optional, default info).
+#   env: OGOUNE_LOG_LEVEL     flag: --log-level
+log_level: info
+
+# Skip TLS verification — DEV / self-signed only. Leave false in production.
+#   env: OGOUNE_INSECURE      flag: --insecure
+insecure_skip_verify: false

--- a/packaging/agent/ogoune-agent.service
+++ b/packaging/agent/ogoune-agent.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Ogoune host monitoring agent
+Documentation=https://docs.ogoune.com
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/ogoune-agent
+# Config is read from /etc/ogoune-agent.yaml by default (override with --config
+# or OGOUNE_* environment variables).
+Restart=on-failure
+RestartSec=5
+# The agent self-heals internally (it retries and slow-backs-off on a revoked
+# credential), so restarts are rare; this mainly covers unexpected crashes.
+
+# Hardening — the agent only reads system metrics and makes an outbound
+# connection; it needs no privileges beyond that.
+DynamicUser=yes
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/agentwire/frame.go
+++ b/pkg/agentwire/frame.go
@@ -1,0 +1,109 @@
+// Package agentwire defines the single, versioned wire contract for the host
+// metrics frame exchanged between the Ogoune agent (cmd/agent) and the backend
+// ingestion route (internal/api/handler/v1/agent_stream_handler.go). Both sides
+// import this package so the frame cannot drift.
+package agentwire
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+)
+
+// SchemaVersion is the current frame schema version. A frame decoded without a
+// schema_version is treated as version 1 (backward compatibility with agents
+// and tests that predate the field).
+const SchemaVersion = 1
+
+// ErrUnsupportedVersion is returned when a frame declares a schema_version
+// greater than SchemaVersion (a newer agent talking to an older backend).
+var ErrUnsupportedVersion = errors.New("agentwire: unsupported schema_version")
+
+// ErrMissingField is returned when a frame omits a required numeric field
+// (cpu_pct, mem_pct, net_in, net_out). Such a frame is malformed and must not
+// be stored — the backend leaves last_seen_at unadvanced.
+var ErrMissingField = errors.New("agentwire: frame missing required field")
+
+// DiskUsage is a per-mount disk utilisation entry.
+type DiskUsage struct {
+	Mount   string  `json:"mount"`
+	UsedPct float64 `json:"used_pct"`
+}
+
+// Frame is one point-in-time host metrics sample sent by the agent. The backend
+// assigns the storage timestamp; the agent never sends one.
+type Frame struct {
+	SchemaVersion int         `json:"schema_version"`
+	OS            string      `json:"os,omitempty"`
+	AgentVersion  string      `json:"agent_version,omitempty"`
+	CPUPct        float64     `json:"cpu_pct"`
+	MemPct        float64     `json:"mem_pct"`
+	NetIn         int64       `json:"net_in"`
+	NetOut        int64       `json:"net_out"`
+	Disks         []DiskUsage `json:"disks"`
+}
+
+// Encode serialises a frame to JSON, stamping the current SchemaVersion when the
+// caller left it zero.
+func Encode(f Frame) ([]byte, error) {
+	if f.SchemaVersion == 0 {
+		f.SchemaVersion = SchemaVersion
+	}
+	b, err := json.Marshal(f)
+	if err != nil {
+		return nil, fmt.Errorf("agentwire: encode: %w", err)
+	}
+	return b, nil
+}
+
+// Decode parses a frame from JSON. An absent/zero schema_version is normalised
+// to 1; a version greater than SchemaVersion returns ErrUnsupportedVersion; a
+// frame omitting a required numeric field returns ErrMissingField. Required
+// fields are probed via pointers so an absent field is distinguishable from a
+// legitimate zero value.
+func Decode(b []byte) (Frame, error) {
+	var probe struct {
+		CPUPct *float64 `json:"cpu_pct"`
+		MemPct *float64 `json:"mem_pct"`
+		NetIn  *int64   `json:"net_in"`
+		NetOut *int64   `json:"net_out"`
+	}
+	if err := json.Unmarshal(b, &probe); err != nil {
+		return Frame{}, fmt.Errorf("agentwire: decode: %w", err)
+	}
+	if probe.CPUPct == nil || probe.MemPct == nil || probe.NetIn == nil || probe.NetOut == nil {
+		return Frame{}, ErrMissingField
+	}
+
+	var f Frame
+	if err := json.Unmarshal(b, &f); err != nil {
+		return Frame{}, fmt.Errorf("agentwire: decode: %w", err)
+	}
+	if f.SchemaVersion == 0 {
+		f.SchemaVersion = 1
+	}
+	if f.SchemaVersion > SchemaVersion {
+		return Frame{}, fmt.Errorf("%w: %d (max %d)", ErrUnsupportedVersion, f.SchemaVersion, SchemaVersion)
+	}
+	return f, nil
+}
+
+// Validate rejects non-finite numeric values. Range clamping to [0,100] is the
+// backend's responsibility (it is the authority), so it is intentionally not
+// done here.
+func (f Frame) Validate() error {
+	if !finite(f.CPUPct) || !finite(f.MemPct) {
+		return errors.New("agentwire: cpu_pct/mem_pct must be finite")
+	}
+	for _, d := range f.Disks {
+		if !finite(d.UsedPct) {
+			return fmt.Errorf("agentwire: disk %q used_pct must be finite", d.Mount)
+		}
+	}
+	return nil
+}
+
+func finite(v float64) bool {
+	return !math.IsNaN(v) && !math.IsInf(v, 0)
+}

--- a/pkg/agentwire/frame_test.go
+++ b/pkg/agentwire/frame_test.go
@@ -1,0 +1,115 @@
+package agentwire
+
+import (
+	"encoding/json"
+	"errors"
+	"math"
+	"testing"
+)
+
+func TestEncodeDecode_RoundTrip(t *testing.T) {
+	in := Frame{
+		OS:           "Ubuntu 24.04",
+		AgentVersion: "0.1.0",
+		CPUPct:       12.4,
+		MemPct:       47.1,
+		NetIn:        10432,
+		NetOut:       88123,
+		Disks:        []DiskUsage{{Mount: "/", UsedPct: 23.0}, {Mount: "/data", UsedPct: 71.2}},
+	}
+	b, err := Encode(in)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	out, err := Decode(b)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if out.SchemaVersion != SchemaVersion {
+		t.Fatalf("SchemaVersion = %d, want %d (Encode should stamp it)", out.SchemaVersion, SchemaVersion)
+	}
+	if out.CPUPct != in.CPUPct || out.MemPct != in.MemPct || out.NetIn != in.NetIn || out.NetOut != in.NetOut {
+		t.Fatalf("scalar mismatch: %+v vs %+v", out, in)
+	}
+	if len(out.Disks) != 2 || out.Disks[1].Mount != "/data" || out.Disks[1].UsedPct != 71.2 {
+		t.Fatalf("disks mismatch: %+v", out.Disks)
+	}
+	if out.OS != in.OS || out.AgentVersion != in.AgentVersion {
+		t.Fatalf("os/agent_version mismatch: %+v", out)
+	}
+}
+
+func TestDecode_AbsentVersionIsV1(t *testing.T) {
+	// A legacy frame (the exact shape spec 079 accepts) with NO schema_version.
+	raw := []byte(`{"os":"Debian 12","cpu_pct":5,"mem_pct":10,"net_in":1,"net_out":2,"disks":[{"mount":"/","used_pct":3}]}`)
+	f, err := Decode(raw)
+	if err != nil {
+		t.Fatalf("Decode legacy: %v", err)
+	}
+	if f.SchemaVersion != 1 {
+		t.Fatalf("absent schema_version → %d, want 1", f.SchemaVersion)
+	}
+	if f.CPUPct != 5 || f.Disks[0].UsedPct != 3 {
+		t.Fatalf("legacy fields not decoded: %+v", f)
+	}
+}
+
+func TestDecode_UnknownVersionRejected(t *testing.T) {
+	raw := []byte(`{"schema_version":999,"cpu_pct":1,"mem_pct":1,"net_in":0,"net_out":0,"disks":[]}`)
+	_, err := Decode(raw)
+	if !errors.Is(err, ErrUnsupportedVersion) {
+		t.Fatalf("expected ErrUnsupportedVersion, got %v", err)
+	}
+}
+
+func TestDecode_Malformed(t *testing.T) {
+	if _, err := Decode([]byte("not json")); err == nil {
+		t.Fatal("expected error decoding malformed JSON")
+	}
+}
+
+func TestDecode_MissingRequiredField(t *testing.T) {
+	// cpu_pct present, mem_pct absent → malformed.
+	raw := []byte(`{"cpu_pct":5,"net_in":1,"net_out":2,"disks":[]}`)
+	_, err := Decode(raw)
+	if !errors.Is(err, ErrMissingField) {
+		t.Fatalf("expected ErrMissingField, got %v", err)
+	}
+	// A real zero value is NOT missing.
+	ok := []byte(`{"cpu_pct":0,"mem_pct":0,"net_in":0,"net_out":0,"disks":[]}`)
+	if _, err := Decode(ok); err != nil {
+		t.Fatalf("zero-valued frame should decode, got %v", err)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	if err := (Frame{CPUPct: 12, MemPct: 30}).Validate(); err != nil {
+		t.Fatalf("valid frame rejected: %v", err)
+	}
+	if err := (Frame{CPUPct: math.NaN()}).Validate(); err == nil {
+		t.Fatal("NaN cpu_pct should be rejected")
+	}
+	if err := (Frame{CPUPct: math.Inf(1)}).Validate(); err == nil {
+		t.Fatal("Inf cpu_pct should be rejected")
+	}
+	if err := (Frame{Disks: []DiskUsage{{Mount: "/", UsedPct: math.NaN()}}}).Validate(); err == nil {
+		t.Fatal("NaN disk used_pct should be rejected")
+	}
+}
+
+func TestEncode_OmitsEmptyOptionalStrings(t *testing.T) {
+	b, err := Encode(Frame{CPUPct: 1, MemPct: 2})
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := m["os"]; ok {
+		t.Fatal("empty os should be omitted")
+	}
+	if m["schema_version"] != float64(SchemaVersion) {
+		t.Fatalf("schema_version = %v, want %d", m["schema_version"], SchemaVersion)
+	}
+}


### PR DESCRIPTION
The Ogoune host agent (spec 080): a Go binary (`cmd/agent`) installed on a monitored Linux host that collects system metrics and streams them to the spec 079 backend over `/api/v1/agent/stream`, authenticated by the host's `ag_live_` credential. Optional and fail-safe.

## Adds
- `pkg/agentwire`: the single shared frame contract (`schema_version` + `Frame`), imported by the agent AND the backend handler so they cannot drift
- `cmd/agent`: config (file + env + flags, precedence flags>env>file>default), gopsutil collector, resilient WS transport (exp back-off cap 30s; 401 → slow-cap ~5min infinite back-off, self-heals on re-validation), signal-clean shutdown
- `packaging/agent/`: systemd unit + annotated config example; `make build-agent`
- Backend: `agent_stream_handler` decodes via `pkg/agentwire`, accepts optional `schema_version` — additive, backward-compatible (a legacy unversioned frame still ingests; 079 regression covered)
- Docs: `cmd/agent/README.md` + `nebula/self-host/agent.md`
- Dep: `github.com/shirou/gopsutil/v4` (BSD-3-Clause, compiled-in)

## Not in scope (separate chantiers)
Hosts UI, eBPF capture, Windows/macOS agents, distro packaging.

## Verification
`make ci-local` green (sqlc/migrations/OpenAPI drift, lint, vue-tsc, race tests, FE tests, license-audit). Race tests: agentwire round-trip + version tolerance, config precedence/validation, collector smoke, transport back-off/auth-policy/self-heal, a real-WebSocket integration test against the real 079 handler, and the 079 versioned+legacy backward-compat regression.