### PR TITLE
fix: monitoring follow-ups — private targets, error detail, tag UX (Vague 1)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,12 @@ type Config struct {
 	// ICMP configuration
 	EnableICMP bool
 
+	// AllowPrivateTargets, when true, lets monitors and toolbox tools reach
+	// private/loopback/link-local addresses (RFC1918 etc.). Default false keeps
+	// the SSRF guard on for public/SaaS instances; self-hosters monitoring their
+	// own LAN set ALLOW_PRIVATE_TARGETS=true.
+	AllowPrivateTargets bool
+
 	// Metrics configuration
 	MetricsEnabled bool
 	MetricsToken   string
@@ -106,6 +112,7 @@ func Load() Config {
 	reminderIntervalMinutes := parseInt(GetEnv("REMINDER_INTERVAL_MINUTES", "0"))
 	groupingWindowSeconds := parseInt(GetEnv("GROUPING_WINDOW_SECONDS", "30"))
 	enableICMP := parseBool(GetEnv("ENABLE_ICMP", "false"), false)
+	allowPrivateTargets := parseBool(GetEnv("ALLOW_PRIVATE_TARGETS", "false"), false)
 	metricsEnabled := parseBool(GetEnv("ENABLE_METRICS", "false"), false)
 	metricsToken := GetEnv("METRICS_TOKEN", "")
 	notificationRetentionDays := parseInt(GetEnv("NOTIFICATION_RETENTION_DAYS", "90"))
@@ -163,6 +170,7 @@ func Load() Config {
 		LogFormat:                      logFormat,
 		LogLevel:                       logLevel,
 		EnableICMP:                     enableICMP,
+		AllowPrivateTargets:            allowPrivateTargets,
 		MetricsEnabled:                 metricsEnabled,
 		MetricsToken:                   metricsToken,
 		NotificationRetentionDays:      notificationRetentionDays,

--- a/internal/monitoring/strategy/dns.go
+++ b/internal/monitoring/strategy/dns.go
@@ -35,7 +35,7 @@ func (s *DNSStrategy) Execute(ctx context.Context, resource *domain.Resource) (d
 	// Informational SSRF warning: DNS strategy resolves but does not connect
 	for _, addr := range addrs {
 		ip := net.ParseIP(addr)
-		if ip != nil && safenet.IsBlockedIP(ip) {
+		if ip != nil && safenet.ShouldBlock(ip) {
 			slog.WarnContext(ctx, "SSRF warning: resolved to blocked IP range",
 				slog.String("event", "ssrf_warning"),
 				slog.String("strategy", "dns"),

--- a/internal/platform/bootstrap/config.go
+++ b/internal/platform/bootstrap/config.go
@@ -8,6 +8,7 @@ import (
 	icmppkg "github.com/denisakp/ogoune/internal/icmp"
 	"github.com/denisakp/ogoune/pkg/crypto"
 	"github.com/denisakp/ogoune/pkg/logger"
+	"github.com/denisakp/ogoune/pkg/safenet"
 )
 
 // InitConfig loads configuration, initializes the logger, and validates the crypto key.
@@ -36,6 +37,12 @@ func InitConfig(app *App) {
 	// Detect ICMP capability at startup
 	icmpCapability := icmppkg.Detect()
 	logICMPCapabilityState(cfg.EnableICMP, icmpCapability)
+
+	// SSRF policy: allow private/LAN targets only when explicitly opted in.
+	safenet.SetAllowPrivate(cfg.AllowPrivateTargets)
+	if cfg.AllowPrivateTargets {
+		slog.Warn("ALLOW_PRIVATE_TARGETS enabled — monitors may reach private/loopback addresses; keep this off on public/multi-tenant instances")
+	}
 
 	slog.Info("authentication configured", "email", cfg.AuthEmail)
 }

--- a/internal/service/toolbox_service.go
+++ b/internal/service/toolbox_service.go
@@ -216,7 +216,7 @@ func (s *ToolboxService) buildResolver(name, custom string) (*net.Resolver, stri
 		if parsed == nil {
 			return nil, "", fmt.Errorf("%w: custom_resolver must be a valid IP", ErrToolboxValidation)
 		}
-		if safenet.IsBlockedIP(parsed) {
+		if safenet.ShouldBlock(parsed) {
 			return nil, "", fmt.Errorf("%w: custom resolver", ErrToolboxTargetBlocked)
 		}
 		ip = host

--- a/pkg/safenet/safenet.go
+++ b/pkg/safenet/safenet.go
@@ -6,7 +6,27 @@ import (
 	"net"
 	"net/url"
 	"strings"
+	"sync/atomic"
 )
+
+// allowPrivate, when true, disables the private/loopback/link-local block so a
+// trusted self-hosted instance can monitor its own LAN (opt-in via
+// ALLOW_PRIVATE_TARGETS). Default false keeps public/SaaS instances SSRF-safe.
+// Set once at startup via SetAllowPrivate.
+var allowPrivate atomic.Bool
+
+// SetAllowPrivate configures whether private-network targets are permitted.
+func SetAllowPrivate(v bool) { allowPrivate.Store(v) }
+
+// AllowPrivate reports the current policy.
+func AllowPrivate() bool { return allowPrivate.Load() }
+
+// ShouldBlock reports whether a resolved IP must be rejected: it is in a blocked
+// range AND private targets are not permitted. This is the decision every SSRF
+// guard should use (IsBlockedIP stays a pure range predicate).
+func ShouldBlock(ip net.IP) bool {
+	return !allowPrivate.Load() && IsBlockedIP(ip)
+}
 
 // blockedCIDRs contains all private, loopback, and link-local CIDR ranges
 // that monitor targets must not resolve to.
@@ -53,7 +73,7 @@ func IsBlockedIP(ip net.IP) bool {
 func ValidateResolvedIPs(host string) error {
 	// Check if host is already an IP
 	if ip := net.ParseIP(host); ip != nil {
-		if IsBlockedIP(ip) {
+		if ShouldBlock(ip) {
 			return fmt.Errorf("internal/private network addresses are not permitted")
 		}
 		return nil
@@ -67,7 +87,7 @@ func ValidateResolvedIPs(host string) error {
 
 	for _, ipStr := range ips {
 		ip := net.ParseIP(ipStr)
-		if ip != nil && IsBlockedIP(ip) {
+		if ip != nil && ShouldBlock(ip) {
 			return fmt.Errorf("internal/private network addresses are not permitted")
 		}
 	}

--- a/pkg/safenet/safenet_test.go
+++ b/pkg/safenet/safenet_test.go
@@ -191,3 +191,41 @@ func TestValidateResolvedIPs_DirectIP(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldBlock_RespectsAllowPrivate(t *testing.T) {
+	priv := net.ParseIP("192.168.1.10")
+	pub := net.ParseIP("8.8.8.8")
+
+	// Default: private is blocked, public is not.
+	SetAllowPrivate(false)
+	if !ShouldBlock(priv) {
+		t.Error("private IP should be blocked by default")
+	}
+	if ShouldBlock(pub) {
+		t.Error("public IP should never be blocked")
+	}
+
+	// Opt-in: private is allowed; public still fine.
+	SetAllowPrivate(true)
+	if ShouldBlock(priv) {
+		t.Error("private IP should be allowed when ALLOW_PRIVATE_TARGETS is set")
+	}
+	if ShouldBlock(pub) {
+		t.Error("public IP should never be blocked")
+	}
+
+	// IsBlockedIP stays a pure range predicate regardless of the flag.
+	if !IsBlockedIP(priv) {
+		t.Error("IsBlockedIP must remain a pure predicate (192.168/16 is private)")
+	}
+
+	SetAllowPrivate(false) // restore default for other tests
+}
+
+func TestValidateResolvedIPs_AllowPrivate(t *testing.T) {
+	SetAllowPrivate(true)
+	defer SetAllowPrivate(false)
+	if err := ValidateResolvedIPs("10.0.0.5"); err != nil {
+		t.Errorf("private IP should validate when allowed: %v", err)
+	}
+}

--- a/pkg/safenet/transport.go
+++ b/pkg/safenet/transport.go
@@ -25,7 +25,7 @@ func SafeDial(ctx context.Context, network, addr string) (net.Conn, error) {
 	}
 
 	// Validate all resolved IPs — block if ANY is in a blocked range
-	if slices.ContainsFunc(ips, IsBlockedIP) {
+	if slices.ContainsFunc(ips, ShouldBlock) {
 		logSecurityEvent("ssrf_block_exec", "", addr, "internal/private network addresses are not permitted")
 		return nil, fmt.Errorf("safenet: connection to %s blocked: internal/private network addresses are not permitted", addr)
 	}

--- a/web/src/components/resources/ResourceForm.vue
+++ b/web/src/components/resources/ResourceForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, reactive, ref, watch } from 'vue'
+import { computed, onMounted, reactive, ref, watch } from 'vue'
 
 import {
   resourceSchema,
@@ -71,6 +71,33 @@ function removeTag(id: string) {
   const tags = (state as unknown as { tags?: string[] }).tags
   if (tags) (state as unknown as { tags: string[] }).tags = tags.filter((t) => t !== id)
 }
+
+function addExistingTag(tag: Tag) {
+  const tags = ((state as unknown as { tags?: string[] }).tags ??= [])
+  if (!tags.includes(tag.id)) tags.push(tag.id)
+  tagInput.value = ''
+}
+
+// Live suggestions of existing tags matching what the operator types, so an
+// existing tag is picked (deduped) instead of silently recreated. A "Create …"
+// row appears only when there's no exact match.
+const tagSuggestions = computed<Tag[]>(() => {
+  const q = tagInput.value.trim().toLowerCase()
+  if (!q) return []
+  const selected = new Set(((state as unknown as { tags?: string[] }).tags ?? []))
+  return availableTags.value
+    .filter((t) => t.name.toLowerCase().includes(q) && !selected.has(t.id))
+    .slice(0, 8)
+})
+const hasExactTag = computed(() => {
+  const q = tagInput.value.trim().toLowerCase()
+  return q !== '' && availableTags.value.some((t) => t.name.toLowerCase() === q)
+})
+
+// Load tags eagerly so matching/dedup works as soon as the operator types.
+onMounted(() => {
+  void loadTags()
+})
 
 type FormState = Record<string, unknown> & { type: ResourceInput['type'] }
 
@@ -409,23 +436,61 @@ defineExpose({ state, onSubmit, formRef, stripExtras })
               />
             </UBadge>
           </div>
-          <div class="flex items-center gap-2">
-            <UInput
-              v-model="tagInput"
-              placeholder="Type a tag name and press Enter"
-              size="sm"
-              class="flex-1"
-              @keydown.enter.prevent="addTagFromInput"
-            />
-            <UButton
-              color="neutral"
-              variant="outline"
-              size="xs"
-              icon="i-lucide-plus"
-              @click="addTagFromInput"
+          <div>
+            <div class="flex items-center gap-2">
+              <UInput
+                v-model="tagInput"
+                placeholder="Search or create a tag…"
+                size="sm"
+                class="flex-1"
+                @keydown.enter.prevent="addTagFromInput"
+              />
+              <UButton
+                color="neutral"
+                variant="outline"
+                size="xs"
+                icon="i-lucide-plus"
+                :disabled="!tagInput.trim()"
+                @click="addTagFromInput"
+              >
+                Add
+              </UButton>
+            </div>
+
+            <!-- Live suggestions: pick an existing tag (deduped) or create a new one. -->
+            <div
+              v-if="tagInput.trim()"
+              class="mt-1 overflow-hidden rounded-md border border-default bg-default shadow-sm"
+              data-testid="tag-suggestions"
             >
-              Add
-            </UButton>
+              <button
+                v-for="t in tagSuggestions"
+                :key="t.id"
+                type="button"
+                class="flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm hover:bg-elevated"
+                @click="addExistingTag(t)"
+              >
+                <UIcon name="i-lucide-tag" class="size-3.5 text-muted" />
+                <span class="truncate">{{ t.name }}</span>
+                <span class="ml-auto text-xs text-muted">existing</span>
+              </button>
+              <button
+                v-if="!hasExactTag"
+                type="button"
+                class="flex w-full items-center gap-2 px-2 py-1.5 text-left text-sm text-primary hover:bg-elevated"
+                data-testid="tag-create"
+                @click="addTagFromInput"
+              >
+                <UIcon name="i-lucide-plus" class="size-3.5" />
+                Create “{{ tagInput.trim() }}”
+              </button>
+              <div
+                v-else-if="tagSuggestions.length === 0"
+                class="px-2 py-1.5 text-xs text-muted"
+              >
+                This tag is already added.
+              </div>
+            </div>
           </div>
         </div>
       </template>

--- a/web/src/core/http/client.ts
+++ b/web/src/core/http/client.ts
@@ -21,8 +21,12 @@ async function normalizeError(error: unknown): Promise<never> {
     // run; the response stream is therefore already consumed. Use `error.data`.
     const body: unknown = (error as HTTPError).data ?? null
 
-    const message = (body as { message?: string } | null)?.message ?? response.statusText
-    const code = (body as { code?: string } | null)?.code
+    // Prefer the human-readable message. v1 uses RFC7807 problem+json, where the
+    // message lives in `detail`; the legacy root API uses `message`. Falling back
+    // to statusText produced the generic "Bad Request" that hid real reasons.
+    const b = body as { message?: string; detail?: string; code?: string } | null
+    const message = b?.detail ?? b?.message ?? response.statusText
+    const code = b?.code
 
     const retryAfterRaw = response.headers.get('retry-after')
     const retryAfterSec = retryAfterRaw


### PR DESCRIPTION
Vague 1 des suites du monitoring d'hôtes (voir `.private/roadmap/agent-monitoring-triage.md`).

## #3 — Private/LAN targets (unblocks self-host testing)
`ALLOW_PRIVATE_TARGETS` env flag (**default `false`**). When `true`, `pkg/safenet` lets monitors + toolbox reach RFC1918/loopback/link-local — so a self-hosted instance can monitor its own LAN (homelab/on-prem/Proxmox). Public/multi-tenant instances keep the SSRF block. Applied at both validate-time and exec-time via a single `safenet.ShouldBlock`; `IsBlockedIP` stays a pure predicate. Startup warns when enabled.

## #4 — Explicit UI errors
The Ky error normaliser read only `body.message`; v1 problem+json puts the message in `detail`, so real reasons were hidden behind a generic "Bad Request". Now `detail ?? message ?? statusText`.

## #5 — Tag input UX
Tags load eagerly; matching existing tags surface as you type (picking one dedupes); a `Create "x"` row shows only when there's no exact match. Fixes the invisible dedup that silently recreated tags.

## Verification
`make ci-local` green. New safenet tests for the flag; ResourceForm + client specs pass.

## Not in this PR
082 (packaging: Docker image + CI + compose + config path) and 083 (operator alerting: agent-down + unread-notif escalation) — separate chantiers.