### PR TITLE
fix(hosts): align in-app install helper with spec 082

### DIFF
--- a/web/src/components/hosts/HostCredentialReveal.vue
+++ b/web/src/components/hosts/HostCredentialReveal.vue
@@ -74,15 +74,18 @@ function onClose() {
     <div class="rounded-md border border-default p-4 text-sm space-y-2">
       <p class="font-medium">Install the agent on your host</p>
       <ol class="list-decimal list-inside text-muted space-y-1">
-        <li>Build the agent: <code class="font-mono">make build-agent</code></li>
         <li>
-          Set <code class="font-mono">backend_url</code> and the
-          <code class="font-mono">credential</code> above in
-          <code class="font-mono">/etc/ogoune-agent.yaml</code>
-          (or <code class="font-mono">OGOUNE_CREDENTIAL</code>).
+          Run the image (or a release binary):
+          <code class="font-mono">docker run --pid=host --network=host …
+            ghcr.io/denisakp/ogoune-agent:latest</code>
         </li>
         <li>
-          Enable the service:
+          Set <code class="font-mono">OGOUNE_BACKEND_URL</code> and the
+          <code class="font-mono">OGOUNE_CREDENTIAL</code> above (env, or
+          <code class="font-mono">/etc/ogoune/agent.cfg</code>).
+        </li>
+        <li>
+          Or as a service:
           <code class="font-mono">sudo systemctl enable --now ogoune-agent</code>
         </li>
       </ol>

--- a/web/src/views/hosts/HostDetailView.vue
+++ b/web/src/views/hosts/HostDetailView.vue
@@ -244,12 +244,14 @@ defineExpose({ host, monitors, loading, notFound, range, setRange, metrics })
         <p class="text-muted mb-2 font-medium text-default">Binary + systemd:</p>
         <pre
           class="overflow-x-auto rounded-md bg-default p-3 text-xs font-mono text-default"
-        ># download ogoune-agent for your platform from the Ogoune releases page
-sudo install -m755 ogoune-agent /usr/local/bin/ogoune-agent
-sudo tee /etc/ogoune-agent.yaml &gt;/dev/null &lt;&lt;'EOF'
-backend_url: wss://your-ogoune/api/v1/agent/stream
-credential: &lt;this host's credential&gt;
+        ># download the release binary for your arch (amd64 / arm64) + verify
+sudo install -m755 ogoune-agent-linux-arm64 /usr/local/bin/ogoune-agent
+sudo mkdir -p /etc/ogoune
+sudo tee /etc/ogoune/agent.cfg &gt;/dev/null &lt;&lt;'EOF'
+OGOUNE_BACKEND_URL=wss://your-ogoune/api/v1/agent/stream
+OGOUNE_CREDENTIAL=&lt;this host's credential&gt;
 EOF
+sudo chmod 600 /etc/ogoune/agent.cfg
 sudo systemctl enable --now ogoune-agent</pre>
         <p class="text-muted mt-3">
           Within ~15 seconds the host reports live metrics and shows as <strong>online</strong>.


### PR DESCRIPTION
The Hosts install helper (host detail panel + credential-reveal modal) still showed pre-082 instructions (`make build-agent`, YAML `/etc/ogoune-agent.yaml`). Updated to the shipped artifacts: release binary + env-style `/etc/ogoune/agent.cfg` (`OGOUNE_*`, mode 0600), matching the nebula + README docs (SC-003). Host tests (36) green; vue-tsc clean.