### PR TITLE
feat(api): server-side search endpoint (spec 084)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/083-operator-alerting"
+  "feature_directory": "specs/084-search-endpoint"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **Server-side search endpoint (spec 084)** — `GET /api/v1/search?q=&limit=&categories=`
+  powering the ⌘K command palette beyond the client-side (in-memory) window. Aggregates
+  case-insensitive substring/prefix matches across monitors (name/target), incidents
+  (cause), and app pages, returns a ranked, capped result set
+  (`{results,total,query_duration_ms}`). Read-only (any valid credential), dual-dialect
+  (SQLite + Postgres via the portable `LOWER() LIKE LOWER() ESCAPE` dynquery predicate,
+  injection-safe), no pagination, no new migration. The palette frontend swap (with a
+  client-side fallback) is a deferred follow-up.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,5 +229,5 @@ Dashboard: http://localhost:9009 (project `ogoune`). Block on CRITICAL/BLOCKER i
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/083-operator-alerting/plan.md`
+`specs/084-search-endpoint/plan.md`
 <!-- SPECKIT END -->

--- a/api/openapi/v1.json
+++ b/api/openapi/v1.json
@@ -1353,6 +1353,49 @@
                 },
                 "type": "object"
             },
+            "github_com_denisakp_ogoune_internal_dto_v1.SearchResponse": {
+                "properties": {
+                    "query_duration_ms": {
+                        "type": "integer"
+                    },
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SearchResult"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "total": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_dto_v1.SearchResult": {
+                "properties": {
+                    "category": {
+                        "description": "Category is one of: resource | incident | page.",
+                        "type": "string"
+                    },
+                    "deep_link": {
+                        "description": "DeepLink is the in-app path that opens the item (e.g. /resources/\u003cid\u003e).",
+                        "type": "string"
+                    },
+                    "id": {
+                        "description": "ID is a stable, category-prefixed id: \"resource:\u003cid\u003e\" | \"incident:\u003cid\u003e\" | \"page:\u003clabel\u003e\".",
+                        "type": "string"
+                    },
+                    "label": {
+                        "description": "Label is the primary human-readable text (monitor name, incident cause, page name).",
+                        "type": "string"
+                    },
+                    "meta": {
+                        "description": "Meta is short context (e.g. a monitor's target), omitted when empty.",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
             "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_AnnouncementResponse": {
                 "properties": {
                     "data": {
@@ -1544,6 +1587,17 @@
                 "properties": {
                     "data": {
                         "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SSLCheckResponse"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MetaResponse"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_SearchResponse": {
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SearchResponse"
                     },
                     "meta": {
                         "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MetaResponse"
@@ -4805,6 +4859,79 @@
                 "summary": "Live-test credentials without persisting (rate-limited 10/min)",
                 "tags": [
                     "resource-credentials"
+                ]
+            }
+        },
+        "/search": {
+            "get": {
+                "description": "Command-palette search across monitors (name/target), incidents (cause), and app pages. Read-only.",
+                "parameters": [
+                    {
+                        "description": "Search query (min 2 characters, matched literally)",
+                        "in": "query",
+                        "name": "q",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Max results (default 30, max 100)",
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Comma-separated filter: resource,incident,page (default all)",
+                        "in": "query",
+                        "name": "categories",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_SearchResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "summary": "Search monitors, incidents, and pages",
+                "tags": [
+                    "search"
                 ]
             }
         },

--- a/api/openapi/v1.yaml
+++ b/api/openapi/v1.yaml
@@ -907,6 +907,39 @@ components:
           type: array
           uniqueItems: false
       type: object
+    github_com_denisakp_ogoune_internal_dto_v1.SearchResponse:
+      properties:
+        query_duration_ms:
+          type: integer
+        results:
+          items:
+            $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SearchResult'
+          type: array
+          uniqueItems: false
+        total:
+          type: integer
+      type: object
+    github_com_denisakp_ogoune_internal_dto_v1.SearchResult:
+      properties:
+        category:
+          description: 'Category is one of: resource | incident | page.'
+          type: string
+        deep_link:
+          description: DeepLink is the in-app path that opens the item (e.g. /resources/<id>).
+          type: string
+        id:
+          description: 'ID is a stable, category-prefixed id: "resource:<id>" | "incident:<id>"
+            | "page:<label>".'
+          type: string
+        label:
+          description: Label is the primary human-readable text (monitor name, incident
+            cause, page name).
+          type: string
+        meta:
+          description: Meta is short context (e.g. a monitor's target), omitted when
+            empty.
+          type: string
+      type: object
     github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_AnnouncementResponse:
       properties:
         data:
@@ -1030,6 +1063,13 @@ components:
       properties:
         data:
           $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SSLCheckResponse'
+        meta:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MetaResponse'
+      type: object
+    github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_SearchResponse:
+      properties:
+        data:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SearchResponse'
         meta:
           $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MetaResponse'
       type: object
@@ -2961,6 +3001,51 @@ paths:
       summary: Live-test credentials without persisting (rate-limited 10/min)
       tags:
       - resource-credentials
+  /search:
+    get:
+      description: Command-palette search across monitors (name/target), incidents
+        (cause), and app pages. Read-only.
+      parameters:
+      - description: Search query (min 2 characters, matched literally)
+        in: query
+        name: q
+        required: true
+        schema:
+          type: string
+      - description: Max results (default 30, max 100)
+        in: query
+        name: limit
+        schema:
+          type: integer
+      - description: 'Comma-separated filter: resource,incident,page (default all)'
+        in: query
+        name: categories
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_SearchResponse'
+          description: OK
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Unauthorized
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Unprocessable Entity
+      security:
+      - BearerAuth: []
+      summary: Search monitors, incidents, and pages
+      tags:
+      - search
   /status:
     get:
       responses:

--- a/internal/api/handler/v1/search_bench_test.go
+++ b/internal/api/handler/v1/search_bench_test.go
@@ -1,0 +1,67 @@
+package v1_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	v1 "github.com/denisakp/ogoune/internal/api/handler/v1"
+	"github.com/denisakp/ogoune/internal/repository/internaltest"
+	"github.com/denisakp/ogoune/internal/repository/store"
+	"github.com/denisakp/ogoune/internal/service"
+	"github.com/go-chi/chi/v5"
+)
+
+func buildSearchBenchRouter(b *testing.B, fx *internaltest.DialectFixture) http.Handler {
+	b.Helper()
+	rr := store.NewResourceRepositorySQLC(fx.Runtime)
+	ir := store.NewIncidentRepositorySQLC(fx.Runtime)
+	h := v1.NewSearchHandler(service.NewSearchService(rr, ir))
+	r := chi.NewRouter()
+	r.Get("/api/v1/search", h.List)
+	return r
+}
+
+// BenchmarkAPI_Search_p95 measures GET /api/v1/search latency (spec 084, SC-002:
+// < 150 ms p95). It uses the shared 300-monitor / 100-incident bench fixture; the
+// query "bench" matches both monitor names (`api-bench-res-*`) and incident causes
+// (`bench_failure`), exercising the full resource + incident + pages path.
+//
+// To validate SC-002 at the target scale, bump apiBenchNumMonitors /
+// apiBenchNumIncidents (bench_test.go) toward ~10k / ~50k and re-run `make bench-api`.
+func BenchmarkAPI_Search_p95(b *testing.B) {
+	fx := internaltest.SetupPostgres(b)
+	if fx == nil {
+		b.Skip("postgres backend unavailable")
+		return
+	}
+	seedAPIBenchFixture(b, fx)
+	router := buildSearchBenchRouter(b, fx)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search?q=bench", nil)
+	const iterations = 1000
+	durations := make([]time.Duration, 0, iterations)
+
+	for i := 0; i < 50; i++ {
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			b.Fatalf("warm-up: unexpected status %d", w.Code)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < iterations; i++ {
+		start := time.Now()
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		durations = append(durations, time.Since(start))
+		if w.Code != http.StatusOK {
+			b.Fatalf("iter %d: unexpected status %d", i, w.Code)
+		}
+	}
+	b.StopTimer()
+
+	reportP95(b, "BenchmarkAPI_Search", durations)
+}

--- a/internal/api/handler/v1/search_handler.go
+++ b/internal/api/handler/v1/search_handler.go
@@ -1,0 +1,81 @@
+package v1
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"strings"
+
+	dtoV1 "github.com/denisakp/ogoune/internal/dto/v1"
+	"github.com/denisakp/ogoune/internal/service"
+)
+
+const (
+	searchMinQueryLen  = 2
+	searchDefaultLimit = 30
+	searchMaxLimit     = 100
+)
+
+// SearchV1ServiceInterface is the search service surface used by the handler.
+type SearchV1ServiceInterface interface {
+	Search(ctx context.Context, q string, opts service.SearchOpts) (dtoV1.SearchResponse, error)
+}
+
+// SearchHandler serves the command-palette search endpoint (spec 084).
+type SearchHandler struct {
+	service SearchV1ServiceInterface
+}
+
+func NewSearchHandler(svc SearchV1ServiceInterface) *SearchHandler {
+	return &SearchHandler{service: svc}
+}
+
+// List handles GET /api/v1/search
+//
+// @Summary     Search monitors, incidents, and pages
+// @Description Command-palette search across monitors (name/target), incidents (cause), and app pages. Read-only.
+// @Tags        search
+// @Security    BearerAuth
+// @Produce     json
+// @Param       q          query string true  "Search query (min 2 characters, matched literally)"
+// @Param       limit      query int    false "Max results (default 30, max 100)"
+// @Param       categories query string false "Comma-separated filter: resource,incident,page (default all)"
+// @Success     200 {object} dtoV1.SingleResponse[dtoV1.SearchResponse]
+// @Failure     401 {object} dtoV1.ErrorResponse
+// @Failure     422 {object} dtoV1.ErrorResponse
+// @Router      /search [get]
+func (h *SearchHandler) List(w http.ResponseWriter, r *http.Request) {
+	q := strings.TrimSpace(r.URL.Query().Get("q"))
+	if len(q) < searchMinQueryLen {
+		respondError(w, r, http.StatusUnprocessableEntity, "VALIDATION_FAILED",
+			"query must be at least 2 characters",
+			dtoV1.FieldError{Field: "q", Message: "must be at least 2 characters"})
+		return
+	}
+
+	limit := searchDefaultLimit
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > searchMaxLimit {
+		limit = searchMaxLimit
+	}
+
+	var cats []string
+	if c := strings.TrimSpace(r.URL.Query().Get("categories")); c != "" {
+		for _, part := range strings.Split(c, ",") {
+			if p := strings.TrimSpace(part); p != "" {
+				cats = append(cats, p)
+			}
+		}
+	}
+
+	resp, err := h.service.Search(r.Context(), q, service.SearchOpts{Limit: limit, Categories: cats})
+	if err != nil {
+		respondError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "search failed")
+		return
+	}
+	respond(w, http.StatusOK, resp)
+}

--- a/internal/api/handler/v1/search_handler_test.go
+++ b/internal/api/handler/v1/search_handler_test.go
@@ -1,0 +1,101 @@
+package v1_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	v1 "github.com/denisakp/ogoune/internal/api/handler/v1"
+	dtoV1 "github.com/denisakp/ogoune/internal/dto/v1"
+	"github.com/denisakp/ogoune/internal/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockSearchService struct {
+	lastQ    string
+	lastOpts service.SearchOpts
+	resp     dtoV1.SearchResponse
+	err      error
+}
+
+func (m *mockSearchService) Search(_ context.Context, q string, opts service.SearchOpts) (dtoV1.SearchResponse, error) {
+	m.lastQ = q
+	m.lastOpts = opts
+	return m.resp, m.err
+}
+
+func doSearch(t *testing.T, mock *mockSearchService, url string) *httptest.ResponseRecorder {
+	t.Helper()
+	h := v1.NewSearchHandler(mock)
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	w := httptest.NewRecorder()
+	h.List(w, req)
+	return w
+}
+
+func TestSearchHandler_ShortQueryIs422(t *testing.T) {
+	for _, u := range []string{"/api/v1/search?q=a", "/api/v1/search", "/api/v1/search?q=%20%20"} {
+		w := doSearch(t, &mockSearchService{}, u)
+		assert.Equal(t, http.StatusUnprocessableEntity, w.Code, u)
+	}
+}
+
+func TestSearchHandler_HappyPath(t *testing.T) {
+	mock := &mockSearchService{resp: dtoV1.SearchResponse{
+		Results:         []dtoV1.SearchResult{{ID: "resource:1", Category: "resource", Label: "api", DeepLink: "/resources/1"}},
+		Total:           1,
+		QueryDurationMs: 3,
+	}}
+	w := doSearch(t, mock, "/api/v1/search?q=api")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "api", mock.lastQ)
+
+	var body struct {
+		Data dtoV1.SearchResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, 1, body.Data.Total)
+	require.Len(t, body.Data.Results, 1)
+	assert.Equal(t, "/resources/1", body.Data.Results[0].DeepLink)
+}
+
+func TestSearchHandler_LimitClamp(t *testing.T) {
+	cases := map[string]int{
+		"/api/v1/search?q=api":            30,  // default
+		"/api/v1/search?q=api&limit=5":    5,   // honored
+		"/api/v1/search?q=api&limit=1000": 100, // clamped
+		"/api/v1/search?q=api&limit=0":    30,  // invalid → default
+		"/api/v1/search?q=api&limit=abc":  30,  // non-numeric → default
+	}
+	for url, want := range cases {
+		mock := &mockSearchService{}
+		doSearch(t, mock, url)
+		assert.Equal(t, want, mock.lastOpts.Limit, url)
+	}
+}
+
+func TestSearchHandler_CategoriesParsed(t *testing.T) {
+	mock := &mockSearchService{}
+	doSearch(t, mock, "/api/v1/search?q=api&categories=incident,%20foo%20,")
+	// handler splits + trims + drops empties; service does the known-set filtering.
+	assert.Equal(t, []string{"incident", "foo"}, mock.lastOpts.Categories)
+
+	mock2 := &mockSearchService{}
+	doSearch(t, mock2, "/api/v1/search?q=api")
+	assert.Nil(t, mock2.lastOpts.Categories, "no categories param ⇒ nil (all)")
+}
+
+func TestSearchHandler_MetacharsLiteral(t *testing.T) {
+	mock := &mockSearchService{}
+	w := doSearch(t, mock, "/api/v1/search?q=%25%25") // "%%"
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "%%", mock.lastQ, "query passed through literally")
+}
+
+func TestSearchHandler_ServiceErrorIs500(t *testing.T) {
+	w := doSearch(t, &mockSearchService{err: context.DeadlineExceeded}, "/api/v1/search?q=api")
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/internal/api/openapi_coverage_test.go
+++ b/internal/api/openapi_coverage_test.go
@@ -35,7 +35,7 @@ func buildRouterForCoverage() http.Handler {
 		handler.NewRuntimeConfigHandler(&config.Config{SSLProvider: "external"}, "test"),
 		handler.NewAuthHandler(nil, nil),
 		handler.NewAccountHandler(nil, nil),
-		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil,
 		nil, nil, nil, // hostV1Handler, agentStreamV1Handler, hostCredentialService
 		false,
 		&config.Config{

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -54,6 +54,7 @@ func NewRouter(
 	escalationV1Handler *v1handler.EscalationHandler,
 	monitorV1Handler *v1handler.MonitorHandler,
 	incidentV1Handler *v1handler.IncidentHandler,
+	searchV1Handler *v1handler.SearchHandler,
 	channelV1Handler *v1handler.NotificationChannelHandler,
 	componentV1Handler *v1handler.ComponentHandler,
 	tagV1Handler *v1handler.TagHandler,
@@ -345,6 +346,8 @@ func NewRouter(
 				r.Get("/", incidentV1Handler.List)
 				r.Get("/{id}", incidentV1Handler.Get)
 			})
+			// Command-palette search (spec 084) — read-only, any valid credential.
+			r.Get("/search", searchV1Handler.List)
 			// Notification channel routes — registered in T029
 			r.Route("/notification-channels", func(r chi.Router) {
 				r.Get("/", channelV1Handler.List)

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -87,6 +87,7 @@ func TestNewRouter_PingIsPublicAndResourcesAreProtected(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil, // searchV1Handler (spec 084)
 		nil, // hostV1Handler
 		nil, // agentStreamV1Handler
 		nil, // hostCredentialService

--- a/internal/dto/v1/search.go
+++ b/internal/dto/v1/search.go
@@ -1,0 +1,24 @@
+package v1
+
+// SearchResult is a single unified command-palette hit (spec 084).
+// @name SearchResult
+type SearchResult struct {
+	// ID is a stable, category-prefixed id: "resource:<id>" | "incident:<id>" | "page:<label>".
+	ID string `json:"id"`
+	// Category is one of: resource | incident | page.
+	Category string `json:"category"`
+	// Label is the primary human-readable text (monitor name, incident cause, page name).
+	Label string `json:"label"`
+	// Meta is short context (e.g. a monitor's target), omitted when empty.
+	Meta string `json:"meta,omitempty"`
+	// DeepLink is the in-app path that opens the item (e.g. /resources/<id>).
+	DeepLink string `json:"deep_link"`
+}
+
+// SearchResponse is the payload of GET /api/v1/search.
+// @name SearchResponse
+type SearchResponse struct {
+	Results         []SearchResult `json:"results"`
+	Total           int            `json:"total"`
+	QueryDurationMs int64          `json:"query_duration_ms"`
+}

--- a/internal/platform/bootstrap/router.go
+++ b/internal/platform/bootstrap/router.go
@@ -71,6 +71,7 @@ func InitRouter(app *App) {
 	// V1 handlers
 	monitorV1Handler := v1handler.NewMonitorHandler(app.ResourceService)
 	incidentV1Handler := v1handler.NewIncidentHandler(incidentAPIService)
+	searchV1Handler := v1handler.NewSearchHandler(service.NewSearchService(app.ResourceRepo, app.IncidentRepo))
 	channelV1Handler := v1handler.NewNotificationChannelHandler(notificationService)
 	componentV1Handler := v1handler.NewComponentHandler(app.ComponentRepo)
 	tagV1Handler := v1handler.NewTagHandler(tagService)
@@ -106,7 +107,7 @@ func InitRouter(app *App) {
 		return
 	}
 
-	apiHandler := api.NewRouter(resourceHandler, pingHandler, activityHandler, tagHandler, componentHandler, statusPageHandler, publicStatusHandler, asCacheRecorder(app.PublicStatusCacheMetr), statusPageSettingsHandler, incidentHandler, incidentUpdateHandler, notificationHandler, maintenanceHandler, statsHandler, systemHandler, runtimeConfigHandler, authHandler, accountHandler, app.AuthService, app.APIKeyService, app.SessionService, sessionHandler, twoFactorV1Handler, escalationV1Handler, monitorV1Handler, incidentV1Handler, channelV1Handler, componentV1Handler, tagV1Handler, statusPageV1Handler, heartbeatV1Handler, credentialV1Handler, toolboxV1Handler, notificationFeedV1Handler, dashboardV1Handler, reportV1Handler, announcementV1Handler, integrationsV1Handler, resourceImportV1Handler, hostV1Handler, agentStreamV1Handler, app.HostCredentialService, cfg.EnableSwagger, cfg)
+	apiHandler := api.NewRouter(resourceHandler, pingHandler, activityHandler, tagHandler, componentHandler, statusPageHandler, publicStatusHandler, asCacheRecorder(app.PublicStatusCacheMetr), statusPageSettingsHandler, incidentHandler, incidentUpdateHandler, notificationHandler, maintenanceHandler, statsHandler, systemHandler, runtimeConfigHandler, authHandler, accountHandler, app.AuthService, app.APIKeyService, app.SessionService, sessionHandler, twoFactorV1Handler, escalationV1Handler, monitorV1Handler, incidentV1Handler, searchV1Handler, channelV1Handler, componentV1Handler, tagV1Handler, statusPageV1Handler, heartbeatV1Handler, credentialV1Handler, toolboxV1Handler, notificationFeedV1Handler, dashboardV1Handler, reportV1Handler, announcementV1Handler, integrationsV1Handler, resourceImportV1Handler, hostV1Handler, agentStreamV1Handler, app.HostCredentialService, cfg.EnableSwagger, cfg)
 
 	// Root router
 	rootRouter := chi.NewRouter()

--- a/internal/repository/sqlc/dynquery/incidents.go
+++ b/internal/repository/sqlc/dynquery/incidents.go
@@ -7,13 +7,14 @@ import (
 	dtoV1 "github.com/denisakp/ogoune/internal/dto/v1"
 )
 
-// IncidentFilter holds parsed ?status=, ?monitor_id=, ?from=, ?to= filters
+// IncidentFilter holds parsed ?status=, ?monitor_id=, ?from=, ?to=, ?q= filters
 // for the v1 /incidents list endpoint. Pointer fields: nil means no filter.
 type IncidentFilter struct {
 	Status    *string
 	MonitorID *string
 	From      *time.Time
 	To        *time.Time
+	Q         *string // free-text search over the incident cause (spec 084)
 }
 
 // Validate returns field-level errors. Cross-field: if both From and To are
@@ -25,6 +26,9 @@ func (f *IncidentFilter) Validate() []dtoV1.FieldError {
 	}
 	if f.From != nil && f.To != nil && f.From.After(*f.To) {
 		errs = append(errs, dtoV1.FieldError{Field: "from", Message: "must be before or equal to 'to'"})
+	}
+	if f.Q != nil && len(*f.Q) > maxQLength {
+		errs = append(errs, dtoV1.FieldError{Field: "q", Message: "query too long"})
 	}
 	return errs
 }
@@ -75,6 +79,10 @@ func incidentPredicates(f IncidentFilter) sq.And {
 	}
 	if f.To != nil {
 		preds = append(preds, sq.LtOrEq{"started_at": *f.To})
+	}
+	if f.Q != nil {
+		like := "%" + likeEscape(*f.Q) + "%"
+		preds = append(preds, sq.Expr(`LOWER(cause) LIKE LOWER(?) ESCAPE '\'`, like))
 	}
 	if len(preds) == 0 {
 		// squirrel sq.And{} renders as `()` which is invalid; pass a tautology.

--- a/internal/repository/sqlc/dynquery/incidents_test.go
+++ b/internal/repository/sqlc/dynquery/incidents_test.go
@@ -66,6 +66,23 @@ func TestBuildIncidentsQuery_FromTo(t *testing.T) {
 	}
 }
 
+func TestBuildIncidentsQuery_Q(t *testing.T) {
+	rowsSQL, rowsArgs, _, _, _ := buildBoth(IncidentFilter{Q: strPtr("timeout")}, 1, 25, sq.Dollar)
+	if !strings.Contains(rowsSQL, "LOWER(cause) LIKE LOWER(") || !strings.Contains(rowsSQL, "ESCAPE") {
+		t.Errorf("expected LOWER(cause) LIKE … ESCAPE clause, got: %s", rowsSQL)
+	}
+	if len(rowsArgs) != 1 || rowsArgs[0] != "%timeout%" {
+		t.Errorf("expected single %%timeout%% arg, got %v", rowsArgs)
+	}
+}
+
+func TestBuildIncidentsQuery_Q_EscapesMetachars(t *testing.T) {
+	_, rowsArgs, _, _, _ := buildBoth(IncidentFilter{Q: strPtr("50%_x")}, 1, 25, sq.Dollar)
+	if len(rowsArgs) != 1 || rowsArgs[0] != `%50\%\_x%` {
+		t.Errorf("expected metacharacters escaped, got %v", rowsArgs)
+	}
+}
+
 func TestBuildIncidentsQuery_AllFilters(t *testing.T) {
 	from := time.Now().Add(-24 * time.Hour)
 	to := time.Now()

--- a/internal/repository/store/incident_repository_filter_test.go
+++ b/internal/repository/store/incident_repository_filter_test.go
@@ -16,6 +16,57 @@ import (
 
 func timePtr(t time.Time) *time.Time { return &t }
 
+// TestIncidentRepository_ListByFilter_Q exercises the free-text `q` search over
+// incident cause (spec 084) on both dialects: case-insensitive substring +
+// metacharacter escape-safety.
+func TestIncidentRepository_ListByFilter_Q(t *testing.T) {
+	internaltest.ForEachDialect(t, func(t *testing.T, fx *internaltest.DialectFixture) {
+		ctx := context.Background()
+		repo := store.NewIncidentRepositorySQLC(fx.Runtime)
+		resRepo := store.NewResourceRepositorySQLC(fx.Runtime)
+
+		mon := "mon-q-" + fx.Dialect
+		_, err := resRepo.Create(ctx, &domain.Resource{
+			Base: domain.Base{ID: mon}, Name: mon, Type: domain.ResourceHTTP,
+			Target: "https://example.com", IsActive: true, Interval: 60, Timeout: 10,
+		})
+		require.NoError(t, err)
+
+		causes := []struct{ id, cause string }{
+			{"c1", "Connection timeout"},
+			{"c2", "DNS resolution failure"},
+			{"c3", "TLS handshake error"},
+			{"c4", "50% packet loss"}, // literal % — must be escaped, not a wildcard
+		}
+		now := time.Now()
+		for i, c := range causes {
+			_, err := repo.Create(ctx, &domain.Incident{
+				Base:       domain.Base{ID: fx.Dialect + "-q-" + c.id, CreatedAt: now.Add(time.Duration(i) * time.Second), UpdatedAt: now},
+				ResourceID: mon, Cause: c.cause, StartedAt: now,
+			})
+			require.NoError(t, err)
+		}
+
+		qf := func(s string) dynquery.IncidentFilter { return dynquery.IncidentFilter{Q: &s} }
+		count := func(s string) int {
+			items, total, err := repo.ListIncidentsByFilter(ctx, qf(s), 1, 50)
+			require.NoError(t, err)
+			assert.Equal(t, total, len(items))
+			return total
+		}
+
+		assert.Equal(t, 1, count("timeout"), "substring on cause")
+		assert.Equal(t, 1, count("TIMEOUT"), "case-insensitive")
+		assert.Equal(t, 1, count("failure"))
+		assert.Equal(t, 1, count("error"))
+		assert.Equal(t, 0, count("nomatch"))
+		// escape-safety: a literal '%' must match only the one cause containing '%',
+		// NOT every row (which is what an unescaped LIKE '%' would do).
+		assert.Equal(t, 1, count("50%"))
+		assert.Equal(t, 1, count("%"))
+	})
+}
+
 // TestIncidentRepository_ListByFilter exercises the dynamic-filter SQL path
 // against both SQLite and Postgres. Seeds incidents across 3
 // monitors with varied resolved states + timestamps.

--- a/internal/service/search_service.go
+++ b/internal/service/search_service.go
@@ -1,0 +1,204 @@
+package service
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	dtoV1 "github.com/denisakp/ogoune/internal/dto/v1"
+	"github.com/denisakp/ogoune/internal/domain"
+	"github.com/denisakp/ogoune/internal/repository/sqlc/dynquery"
+)
+
+// searchPerCategoryCap bounds how many rows each category contributes before
+// scoring/merge, so a broad query stays within the latency budget (spec 084).
+const searchPerCategoryCap = 50
+
+// Search categories.
+const (
+	searchCategoryResource = "resource"
+	searchCategoryIncident = "incident"
+	searchCategoryPage     = "page"
+)
+
+// searchResourceRepo / searchIncidentRepo are the repository subsets the search needs.
+type searchResourceRepo interface {
+	ListResourcesByFilter(ctx context.Context, f dynquery.MonitorFilter, page, perPage int) ([]*domain.Resource, int, error)
+}
+
+type searchIncidentRepo interface {
+	ListIncidentsByFilter(ctx context.Context, f dynquery.IncidentFilter, page, perPage int) ([]*domain.Incident, int, error)
+}
+
+// searchPage is a static command-palette nav target (mirrors useSearchPalette STATIC_PAGES).
+type searchPage struct{ Label, Meta, Path string }
+
+var searchPages = []searchPage{
+	{"Overview", "Dashboard", "/overview"},
+	{"Resources", "All monitors", "/resources"},
+	{"Incidents", "Incident list", "/incidents"},
+	{"Components", "Status grouping", "/components"},
+	{"Maintenance", "Planned windows", "/maintenance"},
+	{"Notifications", "Channels", "/notifications"},
+	{"Escalation", "Policies", "/escalation"},
+	{"API keys", "Settings", "/api-keys"},
+	{"Account", "Settings", "/settings/account"},
+	{"Sessions", "Settings", "/settings/sessions"},
+}
+
+// SearchOpts carries the parsed, validated request options.
+type SearchOpts struct {
+	Limit      int      // already clamped by the handler
+	Categories []string // empty ⇒ all supported categories; unknown values ignored
+}
+
+// SearchService aggregates command-palette search across monitors, incidents, and
+// app pages (spec 084). Read-only; matching is case-insensitive substring via the
+// dynquery repositories; ranking is done here.
+type SearchService struct {
+	resources searchResourceRepo
+	incidents searchIncidentRepo
+}
+
+func NewSearchService(resources searchResourceRepo, incidents searchIncidentRepo) *SearchService {
+	return &SearchService{resources: resources, incidents: incidents}
+}
+
+type scored struct {
+	res       dtoV1.SearchResult
+	score     int
+	updatedAt time.Time
+}
+
+// Search runs the aggregated search. `q` is expected pre-validated (len ≥ 2).
+func (s *SearchService) Search(ctx context.Context, q string, opts SearchOpts) (dtoV1.SearchResponse, error) {
+	start := time.Now()
+	want := wantedCategories(opts.Categories)
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 30
+	}
+
+	var out []scored
+
+	if want[searchCategoryResource] {
+		qv := q
+		rows, _, err := s.resources.ListResourcesByFilter(ctx, dynquery.MonitorFilter{Q: &qv}, 1, searchPerCategoryCap)
+		if err != nil {
+			return dtoV1.SearchResponse{}, err
+		}
+		for _, r := range rows {
+			out = append(out, scored{
+				res: dtoV1.SearchResult{
+					ID: "resource:" + r.ID, Category: searchCategoryResource,
+					Label: r.Name, Meta: r.Target, DeepLink: "/resources/" + r.ID,
+				},
+				score:     maxScore(q, r.Name, r.Target),
+				updatedAt: r.UpdatedAt,
+			})
+		}
+	}
+
+	if want[searchCategoryIncident] {
+		qv := q
+		rows, _, err := s.incidents.ListIncidentsByFilter(ctx, dynquery.IncidentFilter{Q: &qv}, 1, searchPerCategoryCap)
+		if err != nil {
+			return dtoV1.SearchResponse{}, err
+		}
+		for _, i := range rows {
+			label := i.Cause
+			if strings.TrimSpace(label) == "" {
+				label = "Incident"
+			}
+			out = append(out, scored{
+				res: dtoV1.SearchResult{
+					ID: "incident:" + i.ID, Category: searchCategoryIncident,
+					Label: label, Meta: i.Resource.Name, DeepLink: "/incidents/" + i.ID,
+				},
+				score:     maxScore(q, i.Cause),
+				updatedAt: i.UpdatedAt,
+			})
+		}
+	}
+
+	if want[searchCategoryPage] {
+		for _, p := range searchPages {
+			sc := maxScore(q, p.Label, p.Meta)
+			if sc == 0 {
+				continue
+			}
+			out = append(out, scored{
+				res: dtoV1.SearchResult{
+					ID: "page:" + p.Label, Category: searchCategoryPage,
+					Label: p.Label, Meta: p.Meta, DeepLink: p.Path,
+				},
+				score: sc, // pages carry no updated_at → zero time (sorts last within a score tier)
+			})
+		}
+	}
+
+	sort.SliceStable(out, func(a, b int) bool {
+		if out[a].score != out[b].score {
+			return out[a].score > out[b].score
+		}
+		return out[a].updatedAt.After(out[b].updatedAt)
+	})
+	if len(out) > limit {
+		out = out[:limit]
+	}
+
+	results := make([]dtoV1.SearchResult, len(out))
+	for i, s := range out {
+		results[i] = s.res
+	}
+	return dtoV1.SearchResponse{
+		Results:         results,
+		Total:           len(results),
+		QueryDurationMs: time.Since(start).Milliseconds(),
+	}, nil
+}
+
+// wantedCategories returns the set to search: empty input ⇒ all; unknown ignored.
+func wantedCategories(cats []string) map[string]bool {
+	all := map[string]bool{searchCategoryResource: true, searchCategoryIncident: true, searchCategoryPage: true}
+	if len(cats) == 0 {
+		return all
+	}
+	// Non-empty filter: keep only known categories. If the caller asked ONLY for
+	// unknown categories, the result is deterministically empty (they narrowed to
+	// nothing valid) — the handler passes nil (not this) when no filter is given.
+	want := map[string]bool{}
+	for _, c := range cats {
+		c = strings.TrimSpace(strings.ToLower(c))
+		if all[c] {
+			want[c] = true
+		}
+	}
+	return want
+}
+
+// maxScore ranks the query against the best of the given fields:
+// exact (3) > prefix (2) > contained (1) > none (0). Case-insensitive.
+func maxScore(q string, fields ...string) int {
+	ql := strings.ToLower(strings.TrimSpace(q))
+	best := 0
+	for _, f := range fields {
+		fl := strings.ToLower(f)
+		switch {
+		case fl == ql:
+			if 3 > best {
+				best = 3
+			}
+		case strings.HasPrefix(fl, ql):
+			if 2 > best {
+				best = 2
+			}
+		case strings.Contains(fl, ql):
+			if 1 > best {
+				best = 1
+			}
+		}
+	}
+	return best
+}

--- a/internal/service/search_service_test.go
+++ b/internal/service/search_service_test.go
@@ -1,0 +1,140 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/denisakp/ogoune/internal/domain"
+	"github.com/denisakp/ogoune/internal/repository/sqlc/dynquery"
+)
+
+type fakeSearchResources struct{ rows []*domain.Resource }
+
+func (f *fakeSearchResources) ListResourcesByFilter(_ context.Context, _ dynquery.MonitorFilter, _, _ int) ([]*domain.Resource, int, error) {
+	return f.rows, len(f.rows), nil
+}
+
+type fakeSearchIncidents struct{ rows []*domain.Incident }
+
+func (f *fakeSearchIncidents) ListIncidentsByFilter(_ context.Context, _ dynquery.IncidentFilter, _, _ int) ([]*domain.Incident, int, error) {
+	return f.rows, len(f.rows), nil
+}
+
+func res(id, name, target string, updated time.Time) *domain.Resource {
+	r := &domain.Resource{Name: name, Target: target}
+	r.ID = id
+	r.UpdatedAt = updated
+	return r
+}
+
+func inc(id, cause, resourceName string, updated time.Time) *domain.Incident {
+	i := &domain.Incident{Cause: cause}
+	i.ID = id
+	i.UpdatedAt = updated
+	i.Resource = domain.Resource{Name: resourceName}
+	return i
+}
+
+func newSearch(rs []*domain.Resource, is []*domain.Incident) *SearchService {
+	return NewSearchService(&fakeSearchResources{rows: rs}, &fakeSearchIncidents{rows: is})
+}
+
+func TestSearch_ScoringOrder(t *testing.T) {
+	now := time.Now()
+	svc := newSearch([]*domain.Resource{
+		res("1", "my-api", "x", now),     // contained → 1
+		res("2", "api", "x", now),        // exact → 3
+		res("3", "api-gateway", "x", now), // prefix → 2
+	}, nil)
+	resp, err := svc.Search(context.Background(), "api", SearchOpts{Limit: 10, Categories: []string{"resource"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := []string{resp.Results[0].Label, resp.Results[1].Label, resp.Results[2].Label}
+	want := []string{"api", "api-gateway", "my-api"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("rank %d = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+func TestSearch_TiebreakByUpdatedAt(t *testing.T) {
+	older := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	newer := time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC)
+	svc := newSearch([]*domain.Resource{
+		res("old", "api-old", "x", older), // prefix, older
+		res("new", "api-new", "x", newer), // prefix, newer
+	}, nil)
+	resp, _ := svc.Search(context.Background(), "api", SearchOpts{Limit: 10, Categories: []string{"resource"}})
+	if resp.Results[0].Label != "api-new" {
+		t.Fatalf("expected newer first, got %v", []string{resp.Results[0].Label, resp.Results[1].Label})
+	}
+}
+
+func TestSearch_CategoryFilter(t *testing.T) {
+	now := time.Now()
+	svc := newSearch(
+		[]*domain.Resource{res("1", "apiserver", "x", now)},
+		[]*domain.Incident{inc("9", "api timeout", "apiserver", now)},
+	)
+	resp, _ := svc.Search(context.Background(), "api", SearchOpts{Limit: 10, Categories: []string{"incident"}})
+	for _, r := range resp.Results {
+		if r.Category != "incident" {
+			t.Fatalf("category filter leaked %q", r.Category)
+		}
+	}
+	if len(resp.Results) != 1 {
+		t.Fatalf("want 1 incident, got %d", len(resp.Results))
+	}
+}
+
+func TestSearch_UnknownOnlyFilterEmpty(t *testing.T) {
+	now := time.Now()
+	svc := newSearch([]*domain.Resource{res("1", "api", "x", now)}, nil)
+	resp, _ := svc.Search(context.Background(), "api", SearchOpts{Limit: 10, Categories: []string{"nope"}})
+	if resp.Total != 0 || len(resp.Results) != 0 {
+		t.Fatalf("all-unknown filter should be empty, got %d", resp.Total)
+	}
+}
+
+func TestSearch_PagesMatch(t *testing.T) {
+	svc := newSearch(nil, nil)
+	resp, _ := svc.Search(context.Background(), "incid", SearchOpts{Limit: 10}) // all categories
+	found := false
+	for _, r := range resp.Results {
+		if r.Category == "page" && r.Label == "Incidents" && r.DeepLink == "/incidents" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected Incidents page in results, got %+v", resp.Results)
+	}
+}
+
+func TestSearch_LimitCap(t *testing.T) {
+	now := time.Now()
+	rows := make([]*domain.Resource, 5)
+	for i := range rows {
+		rows[i] = res(string(rune('a'+i)), "api", "x", now)
+	}
+	svc := newSearch(rows, nil)
+	resp, _ := svc.Search(context.Background(), "api", SearchOpts{Limit: 2, Categories: []string{"resource"}})
+	if resp.Total != 2 || len(resp.Results) != 2 {
+		t.Fatalf("limit=2 → want 2, got %d", resp.Total)
+	}
+}
+
+func TestSearch_IncidentLabelFallbackAndMeta(t *testing.T) {
+	now := time.Now()
+	svc := newSearch(nil, []*domain.Incident{inc("9", "", "apiserver", now)})
+	resp, _ := svc.Search(context.Background(), "ap", SearchOpts{Limit: 10, Categories: []string{"incident"}})
+	// empty cause → label "Incident"; meta from the (hydrated) resource name.
+	if len(resp.Results) != 1 || resp.Results[0].Label != "Incident" || resp.Results[0].Meta != "apiserver" {
+		t.Fatalf("unexpected incident result: %+v", resp.Results)
+	}
+	if resp.Results[0].DeepLink != "/incidents/9" {
+		t.Fatalf("deep link = %q", resp.Results[0].DeepLink)
+	}
+}

--- a/web/packages/api-types/generated/schema.d.ts
+++ b/web/packages/api-types/generated/schema.d.ts
@@ -2640,6 +2640,70 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Search monitors, incidents, and pages
+         * @description Command-palette search across monitors (name/target), incidents (cause), and app pages. Read-only.
+         */
+        get: {
+            parameters: {
+                query: {
+                    /** @description Search query (min 2 characters, matched literally) */
+                    q: string;
+                    /** @description Max results (default 30, max 100) */
+                    limit?: number;
+                    /** @description Comma-separated filter: resource,incident,page (default all) */
+                    categories?: string;
+                };
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_SearchResponse"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+                /** @description Unprocessable Entity */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/status": {
         parameters: {
             query?: never;
@@ -3883,6 +3947,23 @@ export interface components {
         "github_com_denisakp_ogoune_internal_dto_v1.SaveLayoutRequest": {
             widgets?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.WidgetInstance"][];
         };
+        "github_com_denisakp_ogoune_internal_dto_v1.SearchResponse": {
+            query_duration_ms?: number;
+            results?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SearchResult"][];
+            total?: number;
+        };
+        "github_com_denisakp_ogoune_internal_dto_v1.SearchResult": {
+            /** @description Category is one of: resource | incident | page. */
+            category?: string;
+            /** @description DeepLink is the in-app path that opens the item (e.g. /resources/<id>). */
+            deep_link?: string;
+            /** @description ID is a stable, category-prefixed id: "resource:<id>" | "incident:<id>" | "page:<label>". */
+            id?: string;
+            /** @description Label is the primary human-readable text (monitor name, incident cause, page name). */
+            label?: string;
+            /** @description Meta is short context (e.g. a monitor's target), omitted when empty. */
+            meta?: string;
+        };
         "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_AnnouncementResponse": {
             data?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.AnnouncementResponse"];
             meta?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.MetaResponse"];
@@ -3953,6 +4034,10 @@ export interface components {
         };
         "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_SSLCheckResponse": {
             data?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SSLCheckResponse"];
+            meta?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.MetaResponse"];
+        };
+        "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_SearchResponse": {
+            data?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SearchResponse"];
             meta?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.MetaResponse"];
         };
         "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_TagResponse": {


### PR DESCRIPTION
## Spec 084 — Server-side search endpoint (backend, US1)

`GET /api/v1/search` powering the ⌘K command palette beyond the client-side (in-memory) window — finds monitors, incidents (incl. ones older than the hydrated store), and app pages across the full dataset. Full speckit cycle (specify → clarify → plan → tasks → analyze → implement).

### Endpoint
- `GET /api/v1/search?q=&limit=&categories=` — `q` ≥ 2 (else **422**), `limit` default 30 / **max 100**, `categories` CSV over `{resource,incident,page}` (unknown ignored; all-unknown ⇒ empty). **Read-only** (any valid credential, no `RequireReadWrite`), standard rate limit. Swaggo-annotated; **OpenAPI + fe-types regenerated + committed**.
- Response `{ results:[{id,category,label,meta,deep_link}], total, query_duration_ms }`, ranked **exact > prefix > contained**, tiebroken by `updated_at` DESC, capped to `limit`.

### Implementation — minimal (no migration, no sqlc regen)
- **Resources**: reuse the existing `ListResourcesByFilter(MonitorFilter.Q)` (already does `LOWER(name/target) LIKE`).
- **Incidents**: added `Q` to `dynquery.IncidentFilter` + a `LOWER(cause) LIKE LOWER(?) ESCAPE '\'` predicate — **portable** SQLite+Postgres, **injection-safe** (`likeEscape`).
- **Pages**: static list in `SearchService` (mirrors `useSearchPalette` STATIC_PAGES). Scoring/sort/cap done in Go.

### Clarified decisions
Coverage = monitors + incidents + pages · **backend-only** (palette swap + fuse.js fallback = deferred US2 follow-up) · matching **option A** (LIKE, not tsvector) · **no fuzzy** tier.

### Tests
- dynquery predicate + **dual-dialect** incident-`Q` contract test (case-insensitive, `%` escape-safe, both dialects).
- `SearchService` units (scoring, tiebreak, category filter, cap, pages, incident label/meta).
- Handler units (2-char→422, limit clamp, categories parse, metachars literal, 500 on error).
- Search bench (`search_bench_test.go`) — skips without Postgres; scale the fixture consts to ~10k/50k for the SC-002 (<150 ms p95) number.
- `go test -race` green; `make ci-local` green (incl. OpenAPI + fe-types drift guards).

> **Deferred (US2)**: the `useSearchPalette` swap to this endpoint with a client-side fallback is a separate follow-up (validate the endpoint in prod first, per the PRD).