### PR TITLE
feat(api): monitors↔resources v1 parity, Phase 1 (spec 085)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/084-search-endpoint"
+  "feature_directory": "specs/085-resources-v1-migration"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Monitors API parity with the root resources API (spec 085, Phase 1)** — additive
+  endpoints on `/api/v1/monitors` so the versioned API can become the single source of
+  truth: `GET /{id}/live` (live snapshot), `GET /{id}/uptime-stats`, `POST /{id}/tags`
+  + `DELETE /{id}/tags/{tagID}` (204), `PATCH /{id}` (partial update; `PUT` retained), and
+  the resource-credential routes re-mounted under `/api/v1/monitors/{id}/credentials*`. All
+  reuse the existing services (no new logic, no migration); writes are read/write-scoped.
+  The frontend repoint + root-handler deletion (Phase 2) is a deferred follow-up.
 - **Server-side search endpoint (spec 084)** — `GET /api/v1/search?q=&limit=&categories=`
   powering the ⌘K command palette beyond the client-side (in-memory) window. Aggregates
   case-insensitive substring/prefix matches across monitors (name/target), incidents

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,5 +229,5 @@ Dashboard: http://localhost:9009 (project `ogoune`). Block on CRITICAL/BLOCKER i
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-`specs/084-search-endpoint/plan.md`
+`specs/085-resources-v1-migration/plan.md`
 <!-- SPECKIT END -->

--- a/api/openapi/v1.json
+++ b/api/openapi/v1.json
@@ -1,6 +1,683 @@
 {
     "components": {
         "schemas": {
+            "github_com_denisakp_ogoune_internal_domain.Component": {
+                "properties": {
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "grouping_window_seconds": {
+                        "type": "integer"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "last_notification_status": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.ComponentStatus"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "resources": {
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.Resource"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "updated_at": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_domain.ComponentStatus": {
+                "enum": [
+                    "up",
+                    "degraded",
+                    "down"
+                ],
+                "type": "string",
+                "x-enum-varnames": [
+                    "ComponentStatusUp",
+                    "ComponentStatusDegraded",
+                    "ComponentStatusDown"
+                ]
+            },
+            "github_com_denisakp_ogoune_internal_domain.Incident": {
+                "properties": {
+                    "cause": {
+                        "type": "string"
+                    },
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "details": {
+                        "items": {
+                            "type": "integer"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "diagnostics": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.IncidentDiagnostics"
+                    },
+                    "event_steps": {
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.IncidentEventStep"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "resolved_at": {
+                        "description": "nil = active, timestamp = resolved",
+                        "type": "string"
+                    },
+                    "resource": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.Resource"
+                    },
+                    "resource_id": {
+                        "type": "string"
+                    },
+                    "started_at": {
+                        "type": "string"
+                    },
+                    "updated_at": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_domain.IncidentDiagnostics": {
+                "properties": {
+                    "body_encoded": {
+                        "description": "true if response body is base64 encoded",
+                        "type": "boolean"
+                    },
+                    "body_truncated": {
+                        "description": "true if response body was truncated",
+                        "type": "boolean"
+                    },
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "dns_duration": {
+                        "description": "Milliseconds (0 if not measured)",
+                        "type": "integer"
+                    },
+                    "error_message": {
+                        "description": "Machine-readable error from Go",
+                        "type": "string"
+                    },
+                    "error_summary": {
+                        "description": "Human-friendly explanation",
+                        "type": "string"
+                    },
+                    "failure_type": {
+                        "description": "e.g., connection_timeout, invalid_status_code",
+                        "type": "string"
+                    },
+                    "first_byte_duration": {
+                        "description": "Milliseconds (0 if body not captured)",
+                        "type": "integer"
+                    },
+                    "http_status_code": {
+                        "description": "HTTP status code (-1 if N/A)",
+                        "type": "integer"
+                    },
+                    "icmp_available": {
+                        "description": "ICMP enrichment fields (H2: populated by diagnostic enricher for all DOWN incidents)",
+                        "type": "boolean"
+                    },
+                    "icmp_reachable": {
+                        "description": "whether host replied to ICMP echo",
+                        "type": "boolean"
+                    },
+                    "icmp_rtt_ms": {
+                        "description": "round-trip time in ms; null when unreachable",
+                        "type": "integer"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "incident": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.Incident"
+                    },
+                    "incident_id": {
+                        "type": "string"
+                    },
+                    "keyword": {
+                        "description": "Keyword enrichment fields (populated for keyword monitor incidents only)",
+                        "type": "string"
+                    },
+                    "keyword_found": {
+                        "type": "boolean"
+                    },
+                    "keyword_mode": {
+                        "type": "string"
+                    },
+                    "request_headers": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Sanitized request headers",
+                        "type": "object"
+                    },
+                    "request_method": {
+                        "description": "GET, HEAD, POST, etc.",
+                        "type": "string"
+                    },
+                    "request_timeout": {
+                        "description": "Timeout in seconds",
+                        "type": "integer"
+                    },
+                    "request_url": {
+                        "description": "Full URL being checked",
+                        "type": "string"
+                    },
+                    "response_body": {
+                        "description": "Base64 encoded if needed, truncated to 5KB",
+                        "type": "string"
+                    },
+                    "response_headers": {
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Response headers",
+                        "type": "object"
+                    },
+                    "response_size": {
+                        "description": "Actual response size in bytes",
+                        "type": "integer"
+                    },
+                    "root_cause_hint": {
+                        "description": "enum: icmp_unavailable|host_unreachable|service_down|\"\"",
+                        "type": "string"
+                    },
+                    "tls_duration": {
+                        "description": "Milliseconds (0 if not applicable)",
+                        "type": "integer"
+                    },
+                    "total_duration": {
+                        "description": "Milliseconds",
+                        "type": "integer"
+                    },
+                    "updated_at": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_domain.IncidentEventStep": {
+                "properties": {
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "incident": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.Incident"
+                    },
+                    "incident_id": {
+                        "type": "string"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "step": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.IncidentEventStepType"
+                    },
+                    "updated_at": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_domain.IncidentEventStepType": {
+                "enum": [
+                    "detected",
+                    "resolved",
+                    "alert_sent",
+                    "resource_down_alert",
+                    "resource_up_alert",
+                    "flapping",
+                    "flapping_stabilized",
+                    "reminder",
+                    "component_alert"
+                ],
+                "type": "string",
+                "x-enum-varnames": [
+                    "IncidentEventStepDetected",
+                    "IncidentEventStepResolved",
+                    "IncidentEventStepAlert",
+                    "IncidentEventStepDownAlert",
+                    "IncidentEventStepUpAlert",
+                    "IncidentEventStepFlapping",
+                    "IncidentEventStepFlappingStabilized",
+                    "IncidentEventStepReminder",
+                    "IncidentEventStepComponentAlert"
+                ]
+            },
+            "github_com_denisakp_ogoune_internal_domain.MonitoringActivity": {
+                "properties": {
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "is_maintenance": {
+                        "type": "boolean"
+                    },
+                    "message": {
+                        "type": "string"
+                    },
+                    "resource": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.Resource"
+                    },
+                    "resource_id": {
+                        "type": "string"
+                    },
+                    "response_data": {
+                        "items": {
+                            "type": "integer"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "response_time": {
+                        "type": "integer"
+                    },
+                    "success": {
+                        "type": "boolean"
+                    },
+                    "updated_at": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_domain.NotificationChannel": {
+                "properties": {
+                    "config": {
+                        "description": "JSON configuration specific to channel type",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "enabled_by_default": {
+                        "type": "boolean"
+                    },
+                    "failures_24h": {
+                        "type": "integer"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "last_failure_at": {
+                        "type": "string"
+                    },
+                    "last_sent_at": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.NotificationChannelType"
+                    },
+                    "updated_at": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_domain.NotificationChannelType": {
+                "enum": [
+                    "smtp",
+                    "slack",
+                    "sms"
+                ],
+                "type": "string",
+                "x-enum-varnames": [
+                    "NotificationChannelTypeSMTP",
+                    "NotificationChannelTypeSlack",
+                    "NotificationChannelTypeSMS"
+                ]
+            },
+            "github_com_denisakp_ogoune_internal_domain.Resource": {
+                "properties": {
+                    "component": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.Component"
+                    },
+                    "component_id": {
+                        "type": "string"
+                    },
+                    "confirmation_checks": {
+                        "type": "integer"
+                    },
+                    "confirmation_interval": {
+                        "type": "integer"
+                    },
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "credential": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceCredential"
+                    },
+                    "expiry_alert_thresholds": {
+                        "type": "string"
+                    },
+                    "failure_count": {
+                        "type": "integer"
+                    },
+                    "flap_detection_enabled": {
+                        "type": "boolean"
+                    },
+                    "flap_max_duration_minutes": {
+                        "type": "integer"
+                    },
+                    "flap_started_at": {
+                        "type": "string"
+                    },
+                    "flap_threshold": {
+                        "type": "integer"
+                    },
+                    "flap_window_seconds": {
+                        "type": "integer"
+                    },
+                    "heartbeat_grace": {
+                        "type": "integer"
+                    },
+                    "heartbeat_interval": {
+                        "type": "integer"
+                    },
+                    "heartbeat_slug": {
+                        "type": "string"
+                    },
+                    "host_id": {
+                        "description": "optional link to a monitored host",
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "incident_count_30d": {
+                        "type": "integer"
+                    },
+                    "incidents": {
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.Incident"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "interval": {
+                        "description": "in seconds",
+                        "type": "integer"
+                    },
+                    "is_active": {
+                        "type": "boolean"
+                    },
+                    "keyword": {
+                        "type": "string"
+                    },
+                    "keyword_mode": {
+                        "type": "string"
+                    },
+                    "last_checked": {
+                        "type": "string"
+                    },
+                    "last_ping_at": {
+                        "type": "string"
+                    },
+                    "last_status_transition": {
+                        "type": "string"
+                    },
+                    "metadata": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceMetaData"
+                    },
+                    "metadata_pending": {
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "notification_channels": {
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.NotificationChannel"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "protocol_port": {
+                        "type": "integer"
+                    },
+                    "protocol_type": {
+                        "type": "string"
+                    },
+                    "reminder_interval_minutes": {
+                        "type": "integer"
+                    },
+                    "response_time": {
+                        "type": "integer"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceStatus"
+                    },
+                    "tags": {
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.Tags"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "target": {
+                        "type": "string"
+                    },
+                    "timeout": {
+                        "description": "in seconds",
+                        "type": "integer"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceType"
+                    },
+                    "updated_at": {
+                        "type": "string"
+                    },
+                    "uptime_30d": {
+                        "type": "number"
+                    },
+                    "uptime_7d": {
+                        "type": "number"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_domain.ResourceCredential": {
+                "properties": {
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "resource_id": {
+                        "type": "string"
+                    },
+                    "updated_at": {
+                        "type": "string"
+                    },
+                    "username": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_domain.ResourceMetaData": {
+                "properties": {
+                    "domain_expiration_date": {
+                        "type": "string"
+                    },
+                    "domain_registrar": {
+                        "type": "string"
+                    },
+                    "ssl_expiration_date": {
+                        "type": "string"
+                    },
+                    "ssl_issuer": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_domain.ResourceStatus": {
+                "enum": [
+                    "up",
+                    "down",
+                    "error",
+                    "unknown",
+                    "paused",
+                    "pending",
+                    "warning",
+                    "flapping"
+                ],
+                "type": "string",
+                "x-enum-varnames": [
+                    "StatusUp",
+                    "StatusDown",
+                    "StatusError",
+                    "StatusUnknown",
+                    "StatusPaused",
+                    "StatusPending",
+                    "StatusWarn",
+                    "StatusFlapping"
+                ]
+            },
+            "github_com_denisakp_ogoune_internal_domain.ResourceType": {
+                "enum": [
+                    "http",
+                    "tcp",
+                    "dns",
+                    "icmp",
+                    "heartbeat",
+                    "keyword",
+                    "protocol"
+                ],
+                "type": "string",
+                "x-enum-varnames": [
+                    "ResourceHTTP",
+                    "ResourceTCP",
+                    "ResourceDNS",
+                    "ResourceICMP",
+                    "ResourceHeartbeat",
+                    "ResourceKeyword",
+                    "ResourceProtocol"
+                ]
+            },
+            "github_com_denisakp_ogoune_internal_domain.Tags": {
+                "properties": {
+                    "color": {
+                        "type": "string"
+                    },
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "resources": {
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.Resource"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "updated_at": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_dto.LiveActiveIncident": {
+                "properties": {
+                    "cause": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "started_at": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_dto.LiveSnapshotResponse": {
+                "properties": {
+                    "active_incident": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto.LiveActiveIncident"
+                    },
+                    "fetched_at": {
+                        "type": "string"
+                    },
+                    "recent_activities": {
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.MonitoringActivity"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "resource": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.Resource"
+                    },
+                    "stats": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto.LiveStats"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_dto.LiveStats": {
+                "properties": {
+                    "avg_response_time_24h": {
+                        "type": "integer"
+                    },
+                    "last_response_time": {
+                        "type": "integer"
+                    },
+                    "uptime_24h": {
+                        "type": "number"
+                    },
+                    "uptime_2h": {
+                        "type": "number"
+                    },
+                    "uptime_30d": {
+                        "type": "number"
+                    },
+                    "uptime_7d": {
+                        "type": "number"
+                    }
+                },
+                "type": "object"
+            },
             "github_com_denisakp_ogoune_internal_dto.ProblemDetail": {
                 "properties": {
                     "code": {
@@ -424,6 +1101,18 @@
                     },
                     "uptime_ratio": {
                         "type": "number"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_dto_v1.AddTagsRequest": {
+                "properties": {
+                    "tag_ids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
                     }
                 },
                 "type": "object"
@@ -1077,6 +1766,38 @@
                 },
                 "type": "object"
             },
+            "github_com_denisakp_ogoune_internal_dto_v1.MonitorUptimeStat": {
+                "properties": {
+                    "hour": {
+                        "type": "string"
+                    },
+                    "successful_count": {
+                        "type": "integer"
+                    },
+                    "total_count": {
+                        "type": "integer"
+                    },
+                    "uptime_percent": {
+                        "type": "number"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_dto_v1.MonitorUptimeStatsResponse": {
+                "properties": {
+                    "resource_id": {
+                        "type": "string"
+                    },
+                    "stats": {
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MonitorUptimeStat"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    }
+                },
+                "type": "object"
+            },
             "github_com_denisakp_ogoune_internal_dto_v1.PortResult": {
                 "properties": {
                     "banner": {
@@ -1396,6 +2117,17 @@
                 },
                 "type": "object"
             },
+            "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_LiveSnapshotResponse": {
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto.LiveSnapshotResponse"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MetaResponse"
+                    }
+                },
+                "type": "object"
+            },
             "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_AnnouncementResponse": {
                 "properties": {
                     "data": {
@@ -1532,6 +2264,17 @@
                 "properties": {
                     "data": {
                         "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MonitorResponse"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MetaResponse"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorUptimeStatsResponse": {
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MonitorUptimeStatsResponse"
                     },
                     "meta": {
                         "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MetaResponse"
@@ -3681,6 +4424,90 @@
                     "monitors"
                 ]
             },
+            "patch": {
+                "parameters": [
+                    {
+                        "description": "Monitor ID",
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "oneOf": [
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.UpdateMonitorRequest",
+                                        "summary": "body",
+                                        "description": "Partial update payload"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "description": "Partial update payload",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "summary": "Partially update a monitor",
+                "tags": [
+                    "monitors"
+                ]
+            },
             "put": {
                 "parameters": [
                     {
@@ -3753,6 +4580,269 @@
                 "summary": "Update a monitor",
                 "tags": [
                     "monitors"
+                ]
+            }
+        },
+        "/monitors/{id}/credentials": {
+            "delete": {
+                "parameters": [
+                    {
+                        "description": "Resource ID",
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "summary": "Remove credentials for a resource (revert to no-auth behavior)",
+                "tags": [
+                    "resource-credentials"
+                ]
+            },
+            "get": {
+                "parameters": [
+                    {
+                        "description": "Resource ID",
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "summary": "Get the credential metadata for a resource (password masked)",
+                "tags": [
+                    "resource-credentials"
+                ]
+            },
+            "post": {
+                "parameters": [
+                    {
+                        "description": "Resource ID",
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "oneOf": [
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.CredentialCreateRequest",
+                                        "summary": "body",
+                                        "description": "Credential payload"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "description": "Credential payload",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse"
+                                }
+                            }
+                        },
+                        "description": "Created"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "summary": "Create or replace credentials for a resource",
+                "tags": [
+                    "resource-credentials"
+                ]
+            }
+        },
+        "/monitors/{id}/credentials/test": {
+            "post": {
+                "parameters": [
+                    {
+                        "description": "Resource ID",
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "oneOf": [
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.CredentialCreateRequest",
+                                        "summary": "body",
+                                        "description": "Credential payload (not persisted)"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "description": "Credential payload (not persisted)",
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.CredentialTestResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unprocessable Entity"
+                    },
+                    "429": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Too Many Requests"
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "summary": "Live-test credentials without persisting (rate-limited 10/min)",
+                "tags": [
+                    "resource-credentials"
                 ]
             }
         },
@@ -3879,6 +4969,52 @@
                 ]
             }
         },
+        "/monitors/{id}/live": {
+            "get": {
+                "parameters": [
+                    {
+                        "description": "Monitor ID",
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_LiveSnapshotResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "summary": "Live snapshot of a monitor",
+                "tags": [
+                    "monitors"
+                ]
+            }
+        },
         "/monitors/{id}/pause": {
             "post": {
                 "parameters": [
@@ -3986,6 +5122,179 @@
                     }
                 ],
                 "summary": "Resume a monitor",
+                "tags": [
+                    "monitors"
+                ]
+            }
+        },
+        "/monitors/{id}/tags": {
+            "post": {
+                "parameters": [
+                    {
+                        "description": "Monitor ID",
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "oneOf": [
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.AddTagsRequest",
+                                        "summary": "body",
+                                        "description": "Tag IDs"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "description": "Tag IDs",
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "summary": "Attach tags to a monitor",
+                "tags": [
+                    "monitors"
+                ]
+            }
+        },
+        "/monitors/{id}/tags/{tagID}": {
+            "delete": {
+                "parameters": [
+                    {
+                        "description": "Monitor ID",
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Tag ID",
+                        "in": "path",
+                        "name": "tagID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Forbidden"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "summary": "Detach a tag from a monitor",
+                "tags": [
+                    "monitors"
+                ]
+            }
+        },
+        "/monitors/{id}/uptime-stats": {
+            "get": {
+                "parameters": [
+                    {
+                        "description": "Monitor ID",
+                        "in": "path",
+                        "name": "id",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorUptimeStatsResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    }
+                },
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "summary": "Hourly uptime statistics for a monitor",
                 "tags": [
                     "monitors"
                 ]
@@ -4596,269 +5905,6 @@
                 "summary": "Update the monthly-report configuration",
                 "tags": [
                     "reports"
-                ]
-            }
-        },
-        "/resources/{id}/credentials": {
-            "delete": {
-                "parameters": [
-                    {
-                        "description": "Resource ID",
-                        "in": "path",
-                        "name": "id",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "404": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Not Found"
-                    }
-                },
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "summary": "Remove credentials for a resource (revert to no-auth behavior)",
-                "tags": [
-                    "resource-credentials"
-                ]
-            },
-            "get": {
-                "parameters": [
-                    {
-                        "description": "Resource ID",
-                        "in": "path",
-                        "name": "id",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse"
-                                }
-                            }
-                        },
-                        "description": "OK"
-                    },
-                    "404": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Not Found"
-                    }
-                },
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "summary": "Get the credential metadata for a resource (password masked)",
-                "tags": [
-                    "resource-credentials"
-                ]
-            },
-            "post": {
-                "parameters": [
-                    {
-                        "description": "Resource ID",
-                        "in": "path",
-                        "name": "id",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "oneOf": [
-                                    {
-                                        "type": "object"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.CredentialCreateRequest",
-                                        "summary": "body",
-                                        "description": "Credential payload"
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    "description": "Credential payload",
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse"
-                                }
-                            }
-                        },
-                        "description": "OK"
-                    },
-                    "201": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse"
-                                }
-                            }
-                        },
-                        "description": "Created"
-                    },
-                    "403": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Forbidden"
-                    },
-                    "404": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Not Found"
-                    },
-                    "422": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Unprocessable Entity"
-                    }
-                },
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "summary": "Create or replace credentials for a resource",
-                "tags": [
-                    "resource-credentials"
-                ]
-            }
-        },
-        "/resources/{id}/credentials/test": {
-            "post": {
-                "parameters": [
-                    {
-                        "description": "Resource ID",
-                        "in": "path",
-                        "name": "id",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "oneOf": [
-                                    {
-                                        "type": "object"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.CredentialCreateRequest",
-                                        "summary": "body",
-                                        "description": "Credential payload (not persisted)"
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    "description": "Credential payload (not persisted)",
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.CredentialTestResponse"
-                                }
-                            }
-                        },
-                        "description": "OK"
-                    },
-                    "404": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Not Found"
-                    },
-                    "422": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Unprocessable Entity"
-                    },
-                    "429": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"
-                                }
-                            }
-                        },
-                        "description": "Too Many Requests"
-                    }
-                },
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "summary": "Live-test credentials without persisting (rate-limited 10/min)",
-                "tags": [
-                    "resource-credentials"
                 ]
             }
         },

--- a/api/openapi/v1.yaml
+++ b/api/openapi/v1.yaml
@@ -1,5 +1,483 @@
 components:
   schemas:
+    github_com_denisakp_ogoune_internal_domain.Component:
+      properties:
+        created_at:
+          type: string
+        description:
+          type: string
+        grouping_window_seconds:
+          type: integer
+        id:
+          type: string
+        last_notification_status:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.ComponentStatus'
+        name:
+          type: string
+        resources:
+          items:
+            $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.Resource'
+          type: array
+          uniqueItems: false
+        updated_at:
+          type: string
+      type: object
+    github_com_denisakp_ogoune_internal_domain.ComponentStatus:
+      enum:
+      - up
+      - degraded
+      - down
+      type: string
+      x-enum-varnames:
+      - ComponentStatusUp
+      - ComponentStatusDegraded
+      - ComponentStatusDown
+    github_com_denisakp_ogoune_internal_domain.Incident:
+      properties:
+        cause:
+          type: string
+        created_at:
+          type: string
+        details:
+          items:
+            type: integer
+          type: array
+          uniqueItems: false
+        diagnostics:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.IncidentDiagnostics'
+        event_steps:
+          items:
+            $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.IncidentEventStep'
+          type: array
+          uniqueItems: false
+        id:
+          type: string
+        resolved_at:
+          description: nil = active, timestamp = resolved
+          type: string
+        resource:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.Resource'
+        resource_id:
+          type: string
+        started_at:
+          type: string
+        updated_at:
+          type: string
+      type: object
+    github_com_denisakp_ogoune_internal_domain.IncidentDiagnostics:
+      properties:
+        body_encoded:
+          description: true if response body is base64 encoded
+          type: boolean
+        body_truncated:
+          description: true if response body was truncated
+          type: boolean
+        created_at:
+          type: string
+        dns_duration:
+          description: Milliseconds (0 if not measured)
+          type: integer
+        error_message:
+          description: Machine-readable error from Go
+          type: string
+        error_summary:
+          description: Human-friendly explanation
+          type: string
+        failure_type:
+          description: e.g., connection_timeout, invalid_status_code
+          type: string
+        first_byte_duration:
+          description: Milliseconds (0 if body not captured)
+          type: integer
+        http_status_code:
+          description: HTTP status code (-1 if N/A)
+          type: integer
+        icmp_available:
+          description: 'ICMP enrichment fields (H2: populated by diagnostic enricher
+            for all DOWN incidents)'
+          type: boolean
+        icmp_reachable:
+          description: whether host replied to ICMP echo
+          type: boolean
+        icmp_rtt_ms:
+          description: round-trip time in ms; null when unreachable
+          type: integer
+        id:
+          type: string
+        incident:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.Incident'
+        incident_id:
+          type: string
+        keyword:
+          description: Keyword enrichment fields (populated for keyword monitor incidents
+            only)
+          type: string
+        keyword_found:
+          type: boolean
+        keyword_mode:
+          type: string
+        request_headers:
+          additionalProperties:
+            type: string
+          description: Sanitized request headers
+          type: object
+        request_method:
+          description: GET, HEAD, POST, etc.
+          type: string
+        request_timeout:
+          description: Timeout in seconds
+          type: integer
+        request_url:
+          description: Full URL being checked
+          type: string
+        response_body:
+          description: Base64 encoded if needed, truncated to 5KB
+          type: string
+        response_headers:
+          additionalProperties:
+            type: string
+          description: Response headers
+          type: object
+        response_size:
+          description: Actual response size in bytes
+          type: integer
+        root_cause_hint:
+          description: 'enum: icmp_unavailable|host_unreachable|service_down|""'
+          type: string
+        tls_duration:
+          description: Milliseconds (0 if not applicable)
+          type: integer
+        total_duration:
+          description: Milliseconds
+          type: integer
+        updated_at:
+          type: string
+      type: object
+    github_com_denisakp_ogoune_internal_domain.IncidentEventStep:
+      properties:
+        created_at:
+          type: string
+        id:
+          type: string
+        incident:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.Incident'
+        incident_id:
+          type: string
+        message:
+          type: string
+        step:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.IncidentEventStepType'
+        updated_at:
+          type: string
+      type: object
+    github_com_denisakp_ogoune_internal_domain.IncidentEventStepType:
+      enum:
+      - detected
+      - resolved
+      - alert_sent
+      - resource_down_alert
+      - resource_up_alert
+      - flapping
+      - flapping_stabilized
+      - reminder
+      - component_alert
+      type: string
+      x-enum-varnames:
+      - IncidentEventStepDetected
+      - IncidentEventStepResolved
+      - IncidentEventStepAlert
+      - IncidentEventStepDownAlert
+      - IncidentEventStepUpAlert
+      - IncidentEventStepFlapping
+      - IncidentEventStepFlappingStabilized
+      - IncidentEventStepReminder
+      - IncidentEventStepComponentAlert
+    github_com_denisakp_ogoune_internal_domain.MonitoringActivity:
+      properties:
+        created_at:
+          type: string
+        id:
+          type: string
+        is_maintenance:
+          type: boolean
+        message:
+          type: string
+        resource:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.Resource'
+        resource_id:
+          type: string
+        response_data:
+          items:
+            type: integer
+          type: array
+          uniqueItems: false
+        response_time:
+          type: integer
+        success:
+          type: boolean
+        updated_at:
+          type: string
+      type: object
+    github_com_denisakp_ogoune_internal_domain.NotificationChannel:
+      properties:
+        config:
+          description: JSON configuration specific to channel type
+          items:
+            type: integer
+          type: array
+          uniqueItems: false
+        created_at:
+          type: string
+        enabled_by_default:
+          type: boolean
+        failures_24h:
+          type: integer
+        id:
+          type: string
+        last_failure_at:
+          type: string
+        last_sent_at:
+          type: string
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.NotificationChannelType'
+        updated_at:
+          type: string
+      type: object
+    github_com_denisakp_ogoune_internal_domain.NotificationChannelType:
+      enum:
+      - smtp
+      - slack
+      - sms
+      type: string
+      x-enum-varnames:
+      - NotificationChannelTypeSMTP
+      - NotificationChannelTypeSlack
+      - NotificationChannelTypeSMS
+    github_com_denisakp_ogoune_internal_domain.Resource:
+      properties:
+        component:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.Component'
+        component_id:
+          type: string
+        confirmation_checks:
+          type: integer
+        confirmation_interval:
+          type: integer
+        created_at:
+          type: string
+        credential:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceCredential'
+        expiry_alert_thresholds:
+          type: string
+        failure_count:
+          type: integer
+        flap_detection_enabled:
+          type: boolean
+        flap_max_duration_minutes:
+          type: integer
+        flap_started_at:
+          type: string
+        flap_threshold:
+          type: integer
+        flap_window_seconds:
+          type: integer
+        heartbeat_grace:
+          type: integer
+        heartbeat_interval:
+          type: integer
+        heartbeat_slug:
+          type: string
+        host_id:
+          description: optional link to a monitored host
+          type: string
+        id:
+          type: string
+        incident_count_30d:
+          type: integer
+        incidents:
+          items:
+            $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.Incident'
+          type: array
+          uniqueItems: false
+        interval:
+          description: in seconds
+          type: integer
+        is_active:
+          type: boolean
+        keyword:
+          type: string
+        keyword_mode:
+          type: string
+        last_checked:
+          type: string
+        last_ping_at:
+          type: string
+        last_status_transition:
+          type: string
+        metadata:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceMetaData'
+        metadata_pending:
+          type: boolean
+        name:
+          type: string
+        notification_channels:
+          items:
+            $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.NotificationChannel'
+          type: array
+          uniqueItems: false
+        protocol_port:
+          type: integer
+        protocol_type:
+          type: string
+        reminder_interval_minutes:
+          type: integer
+        response_time:
+          type: integer
+        status:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceStatus'
+        tags:
+          items:
+            $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.Tags'
+          type: array
+          uniqueItems: false
+        target:
+          type: string
+        timeout:
+          description: in seconds
+          type: integer
+        type:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceType'
+        updated_at:
+          type: string
+        uptime_7d:
+          type: number
+        uptime_30d:
+          type: number
+      type: object
+    github_com_denisakp_ogoune_internal_domain.ResourceCredential:
+      properties:
+        created_at:
+          type: string
+        id:
+          type: string
+        resource_id:
+          type: string
+        updated_at:
+          type: string
+        username:
+          type: string
+      type: object
+    github_com_denisakp_ogoune_internal_domain.ResourceMetaData:
+      properties:
+        domain_expiration_date:
+          type: string
+        domain_registrar:
+          type: string
+        ssl_expiration_date:
+          type: string
+        ssl_issuer:
+          type: string
+      type: object
+    github_com_denisakp_ogoune_internal_domain.ResourceStatus:
+      enum:
+      - up
+      - down
+      - error
+      - unknown
+      - paused
+      - pending
+      - warning
+      - flapping
+      type: string
+      x-enum-varnames:
+      - StatusUp
+      - StatusDown
+      - StatusError
+      - StatusUnknown
+      - StatusPaused
+      - StatusPending
+      - StatusWarn
+      - StatusFlapping
+    github_com_denisakp_ogoune_internal_domain.ResourceType:
+      enum:
+      - http
+      - tcp
+      - dns
+      - icmp
+      - heartbeat
+      - keyword
+      - protocol
+      type: string
+      x-enum-varnames:
+      - ResourceHTTP
+      - ResourceTCP
+      - ResourceDNS
+      - ResourceICMP
+      - ResourceHeartbeat
+      - ResourceKeyword
+      - ResourceProtocol
+    github_com_denisakp_ogoune_internal_domain.Tags:
+      properties:
+        color:
+          type: string
+        created_at:
+          type: string
+        description:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        resources:
+          items:
+            $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.Resource'
+          type: array
+          uniqueItems: false
+        updated_at:
+          type: string
+      type: object
+    github_com_denisakp_ogoune_internal_dto.LiveActiveIncident:
+      properties:
+        cause:
+          type: string
+        id:
+          type: string
+        started_at:
+          type: string
+      type: object
+    github_com_denisakp_ogoune_internal_dto.LiveSnapshotResponse:
+      properties:
+        active_incident:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto.LiveActiveIncident'
+        fetched_at:
+          type: string
+        recent_activities:
+          items:
+            $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.MonitoringActivity'
+          type: array
+          uniqueItems: false
+        resource:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.Resource'
+        stats:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto.LiveStats'
+      type: object
+    github_com_denisakp_ogoune_internal_dto.LiveStats:
+      properties:
+        avg_response_time_24h:
+          type: integer
+        last_response_time:
+          type: integer
+        uptime_24h:
+          type: number
+        uptime_2h:
+          type: number
+        uptime_7d:
+          type: number
+        uptime_30d:
+          type: number
+      type: object
     github_com_denisakp_ogoune_internal_dto.ProblemDetail:
       properties:
         code:
@@ -292,6 +770,14 @@ components:
           type: integer
         uptime_ratio:
           type: number
+      type: object
+    github_com_denisakp_ogoune_internal_dto_v1.AddTagsRequest:
+      properties:
+        tag_ids:
+          items:
+            type: string
+          type: array
+          uniqueItems: false
       type: object
     github_com_denisakp_ogoune_internal_dto_v1.AnnouncementResponse:
       properties:
@@ -723,6 +1209,27 @@ components:
         updated_at:
           type: string
       type: object
+    github_com_denisakp_ogoune_internal_dto_v1.MonitorUptimeStat:
+      properties:
+        hour:
+          type: string
+        successful_count:
+          type: integer
+        total_count:
+          type: integer
+        uptime_percent:
+          type: number
+      type: object
+    github_com_denisakp_ogoune_internal_dto_v1.MonitorUptimeStatsResponse:
+      properties:
+        resource_id:
+          type: string
+        stats:
+          items:
+            $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MonitorUptimeStat'
+          type: array
+          uniqueItems: false
+      type: object
     github_com_denisakp_ogoune_internal_dto_v1.PortResult:
       properties:
         banner:
@@ -940,6 +1447,13 @@ components:
             empty.
           type: string
       type: object
+    github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_LiveSnapshotResponse:
+      properties:
+        data:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto.LiveSnapshotResponse'
+        meta:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MetaResponse'
+      type: object
     github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_AnnouncementResponse:
       properties:
         data:
@@ -1028,6 +1542,13 @@ components:
       properties:
         data:
           $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MonitorResponse'
+        meta:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MetaResponse'
+      type: object
+    github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorUptimeStatsResponse:
+      properties:
+        data:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MonitorUptimeStatsResponse'
         meta:
           $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MetaResponse'
       type: object
@@ -2245,6 +2766,55 @@ paths:
       summary: Get a monitor by ID
       tags:
       - monitors
+    patch:
+      parameters:
+      - description: Monitor ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - type: object
+              - $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.UpdateMonitorRequest'
+                description: Partial update payload
+                summary: body
+        description: Partial update payload
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse'
+          description: OK
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Not Found
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Unprocessable Entity
+      security:
+      - BearerAuth: []
+      summary: Partially update a monitor
+      tags:
+      - monitors
     put:
       parameters:
       - description: Monitor ID
@@ -2288,6 +2858,160 @@ paths:
       summary: Update a monitor
       tags:
       - monitors
+  /monitors/{id}/credentials:
+    delete:
+      parameters:
+      - description: Resource ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: No Content
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Not Found
+      security:
+      - BearerAuth: []
+      summary: Remove credentials for a resource (revert to no-auth behavior)
+      tags:
+      - resource-credentials
+    get:
+      parameters:
+      - description: Resource ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse'
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Not Found
+      security:
+      - BearerAuth: []
+      summary: Get the credential metadata for a resource (password masked)
+      tags:
+      - resource-credentials
+    post:
+      parameters:
+      - description: Resource ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - type: object
+              - $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.CredentialCreateRequest'
+                description: Credential payload
+                summary: body
+        description: Credential payload
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse'
+          description: OK
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse'
+          description: Created
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Not Found
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Unprocessable Entity
+      security:
+      - BearerAuth: []
+      summary: Create or replace credentials for a resource
+      tags:
+      - resource-credentials
+  /monitors/{id}/credentials/test:
+    post:
+      parameters:
+      - description: Resource ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - type: object
+              - $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.CredentialCreateRequest'
+                description: Credential payload (not persisted)
+                summary: body
+        description: Credential payload (not persisted)
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.CredentialTestResponse'
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Not Found
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Too Many Requests
+      security:
+      - BearerAuth: []
+      summary: Live-test credentials without persisting (rate-limited 10/min)
+      tags:
+      - resource-credentials
   /monitors/{id}/host:
     delete:
       parameters:
@@ -2360,6 +3084,33 @@ paths:
       summary: Link a monitor to a host
       tags:
       - monitors
+  /monitors/{id}/live:
+    get:
+      parameters:
+      - description: Monitor ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_LiveSnapshotResponse'
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Not Found
+      security:
+      - BearerAuth: []
+      summary: Live snapshot of a monitor
+      tags:
+      - monitors
   /monitors/{id}/pause:
     post:
       parameters:
@@ -2424,6 +3175,108 @@ paths:
       security:
       - BearerAuth: []
       summary: Resume a monitor
+      tags:
+      - monitors
+  /monitors/{id}/tags:
+    post:
+      parameters:
+      - description: Monitor ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+              - type: object
+              - $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.AddTagsRequest'
+                description: Tag IDs
+                summary: body
+        description: Tag IDs
+        required: true
+      responses:
+        "204":
+          description: No Content
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Not Found
+      security:
+      - BearerAuth: []
+      summary: Attach tags to a monitor
+      tags:
+      - monitors
+  /monitors/{id}/tags/{tagID}:
+    delete:
+      parameters:
+      - description: Monitor ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      - description: Tag ID
+        in: path
+        name: tagID
+        required: true
+        schema:
+          type: string
+      responses:
+        "204":
+          description: No Content
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Forbidden
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Not Found
+      security:
+      - BearerAuth: []
+      summary: Detach a tag from a monitor
+      tags:
+      - monitors
+  /monitors/{id}/uptime-stats:
+    get:
+      parameters:
+      - description: Monitor ID
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorUptimeStatsResponse'
+          description: OK
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
+          description: Not Found
+      security:
+      - BearerAuth: []
+      summary: Hourly uptime statistics for a monitor
       tags:
       - monitors
   /monitors/export:
@@ -2847,160 +3700,6 @@ paths:
       summary: Update the monthly-report configuration
       tags:
       - reports
-  /resources/{id}/credentials:
-    delete:
-      parameters:
-      - description: Resource ID
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      responses:
-        "204":
-          description: No Content
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
-          description: Not Found
-      security:
-      - BearerAuth: []
-      summary: Remove credentials for a resource (revert to no-auth behavior)
-      tags:
-      - resource-credentials
-    get:
-      parameters:
-      - description: Resource ID
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse'
-          description: OK
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
-          description: Not Found
-      security:
-      - BearerAuth: []
-      summary: Get the credential metadata for a resource (password masked)
-      tags:
-      - resource-credentials
-    post:
-      parameters:
-      - description: Resource ID
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - type: object
-              - $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.CredentialCreateRequest'
-                description: Credential payload
-                summary: body
-        description: Credential payload
-        required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse'
-          description: OK
-        "201":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse'
-          description: Created
-        "403":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
-          description: Forbidden
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
-          description: Not Found
-        "422":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
-          description: Unprocessable Entity
-      security:
-      - BearerAuth: []
-      summary: Create or replace credentials for a resource
-      tags:
-      - resource-credentials
-  /resources/{id}/credentials/test:
-    post:
-      parameters:
-      - description: Resource ID
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              oneOf:
-              - type: object
-              - $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.CredentialCreateRequest'
-                description: Credential payload (not persisted)
-                summary: body
-        description: Credential payload (not persisted)
-        required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.CredentialTestResponse'
-          description: OK
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
-          description: Not Found
-        "422":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
-          description: Unprocessable Entity
-        "429":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse'
-          description: Too Many Requests
-      security:
-      - BearerAuth: []
-      summary: Live-test credentials without persisting (rate-limited 10/min)
-      tags:
-      - resource-credentials
   /search:
     get:
       description: Command-palette search across monitors (name/target), incidents

--- a/internal/api/handler/v1/bench_test.go
+++ b/internal/api/handler/v1/bench_test.go
@@ -64,6 +64,12 @@ func (s *benchMonitorService) DeleteResource(_ context.Context, _ string) error 
 func (s *benchMonitorService) PauseMonitoring(_ context.Context, _ string) error {
 	panic("bench harness: PauseMonitoring not used")
 }
+func (s *benchMonitorService) AddTagsToResource(_ context.Context, _ string, _ []string) error {
+	panic("bench harness: AddTagsToResource not used")
+}
+func (s *benchMonitorService) RemoveTagFromResource(_ context.Context, _, _ string) error {
+	panic("bench harness: RemoveTagFromResource not used")
+}
 func (s *benchMonitorService) ResumeMonitoring(_ context.Context, _ string) error {
 	panic("bench harness: ResumeMonitoring not used")
 }
@@ -146,7 +152,7 @@ func buildBenchRouter(b *testing.B, fx *internaltest.DialectFixture) http.Handle
 	b.Helper()
 	resourceRepo := store.NewResourceRepositorySQLC(fx.Runtime)
 	incidentRepo := store.NewIncidentRepositorySQLC(fx.Runtime)
-	monitorHandler := v1.NewMonitorHandler(&benchMonitorService{repo: resourceRepo})
+	monitorHandler := v1.NewMonitorHandler(&benchMonitorService{repo: resourceRepo}, nil, nil)
 	incidentHandler := v1.NewIncidentHandler(&benchIncidentService{repo: incidentRepo})
 
 	r := chi.NewRouter()

--- a/internal/api/handler/v1/monitor_handler.go
+++ b/internal/api/handler/v1/monitor_handler.go
@@ -27,16 +27,32 @@ type MonitorV1ServiceInterface interface {
 	DeleteResource(ctx context.Context, resourceID string) error
 	PauseMonitoring(ctx context.Context, resourceID string) error
 	ResumeMonitoring(ctx context.Context, resourceID string) error
+	// spec 085 — parity with the root resources API
+	AddTagsToResource(ctx context.Context, resourceID string, tagIDs []string) error
+	RemoveTagFromResource(ctx context.Context, resourceID, tagID string) error
+}
+
+// monitorLiveProvider is the live-snapshot service subset (spec 085 parity).
+type monitorLiveProvider interface {
+	GetLiveSnapshot(ctx context.Context, resourceID string) (*dto.LiveSnapshotResponse, error)
+}
+
+// monitorUptimeProvider is the uptime-stats service subset (spec 085 parity).
+type monitorUptimeProvider interface {
+	GetUptimeStats(ctx context.Context, resourceID string) ([]dto.UptimeStatResponse, error)
 }
 
 // MonitorHandler handles v1 CRUD and lifecycle endpoints for monitors.
 type MonitorHandler struct {
 	service MonitorV1ServiceInterface
+	live    monitorLiveProvider
+	uptime  monitorUptimeProvider
 }
 
-// NewMonitorHandler creates a new MonitorHandler with the given service.
-func NewMonitorHandler(svc MonitorV1ServiceInterface) *MonitorHandler {
-	return &MonitorHandler{service: svc}
+// NewMonitorHandler creates a new MonitorHandler. live/uptime may be nil (their
+// endpoints then return 503); bootstrap injects the real services.
+func NewMonitorHandler(svc MonitorV1ServiceInterface, live monitorLiveProvider, uptime monitorUptimeProvider) *MonitorHandler {
+	return &MonitorHandler{service: svc, live: live, uptime: uptime}
 }
 
 // mapMonitorResponse maps a domain.Resource to a v1 MonitorResponse.
@@ -205,7 +221,7 @@ func (h *MonitorHandler) Create(w http.ResponseWriter, r *http.Request) {
 	respond(w, http.StatusCreated, mapMonitorResponse(created))
 }
 
-// Update handles PUT /api/v1/monitors/{id}
+// Update handles PUT /api/v1/monitors/{id} (full-shape update; partial semantics).
 //
 // @Summary     Update a monitor
 // @Tags        monitors
@@ -218,7 +234,28 @@ func (h *MonitorHandler) Create(w http.ResponseWriter, r *http.Request) {
 // @Failure     404 {object} dtoV1.ErrorResponse
 // @Failure     403 {object} dtoV1.ErrorResponse
 // @Router      /monitors/{id} [put]
-func (h *MonitorHandler) Update(w http.ResponseWriter, r *http.Request) {
+func (h *MonitorHandler) Update(w http.ResponseWriter, r *http.Request) { h.applyUpdate(w, r) }
+
+// Patch handles PATCH /api/v1/monitors/{id} — partial update; only supplied fields
+// change, unset fields are preserved (spec 085 parity with the root PATCH).
+//
+// @Summary     Partially update a monitor
+// @Tags        monitors
+// @Security    BearerAuth
+// @Accept      json
+// @Produce     json
+// @Param       id   path string true "Monitor ID"
+// @Param       body body dtoV1.UpdateMonitorRequest true "Partial update payload"
+// @Success     200 {object} dtoV1.SingleResponse[dtoV1.MonitorResponse]
+// @Failure     404 {object} dtoV1.ErrorResponse
+// @Failure     403 {object} dtoV1.ErrorResponse
+// @Failure     422 {object} dtoV1.ErrorResponse
+// @Router      /monitors/{id} [patch]
+func (h *MonitorHandler) Patch(w http.ResponseWriter, r *http.Request) { h.applyUpdate(w, r) }
+
+// applyUpdate decodes the pointer-shaped UpdateMonitorRequest and applies it as a
+// partial update (shared by PUT + PATCH).
+func (h *MonitorHandler) applyUpdate(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	var req dtoV1.UpdateMonitorRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -258,6 +295,116 @@ func (h *MonitorHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	respond(w, http.StatusOK, mapMonitorResponse(updated))
+}
+
+// GetLive handles GET /api/v1/monitors/{id}/live — live snapshot (spec 085 parity).
+//
+// @Summary     Live snapshot of a monitor
+// @Tags        monitors
+// @Security    BearerAuth
+// @Produce     json
+// @Param       id path string true "Monitor ID"
+// @Success     200 {object} dtoV1.SingleResponse[dto.LiveSnapshotResponse]
+// @Failure     404 {object} dtoV1.ErrorResponse
+// @Router      /monitors/{id}/live [get]
+func (h *MonitorHandler) GetLive(w http.ResponseWriter, r *http.Request) {
+	if h.live == nil {
+		respondError(w, r, http.StatusServiceUnavailable, "UNAVAILABLE", "live snapshot service not available")
+		return
+	}
+	snapshot, err := h.live.GetLiveSnapshot(r.Context(), chi.URLParam(r, "id"))
+	if err != nil {
+		if errors.Is(err, service.ErrResourceNotFound) {
+			respondError(w, r, http.StatusNotFound, "RESOURCE_NOT_FOUND", "monitor not found")
+			return
+		}
+		respondError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to load live snapshot")
+		return
+	}
+	respond(w, http.StatusOK, snapshot)
+}
+
+// GetUptimeStats handles GET /api/v1/monitors/{id}/uptime-stats (spec 085 parity).
+//
+// @Summary     Hourly uptime statistics for a monitor
+// @Tags        monitors
+// @Security    BearerAuth
+// @Produce     json
+// @Param       id path string true "Monitor ID"
+// @Success     200 {object} dtoV1.SingleResponse[dtoV1.MonitorUptimeStatsResponse]
+// @Failure     404 {object} dtoV1.ErrorResponse
+// @Router      /monitors/{id}/uptime-stats [get]
+func (h *MonitorHandler) GetUptimeStats(w http.ResponseWriter, r *http.Request) {
+	if h.uptime == nil {
+		respondError(w, r, http.StatusServiceUnavailable, "UNAVAILABLE", "uptime service not available")
+		return
+	}
+	id := chi.URLParam(r, "id")
+	stats, err := h.uptime.GetUptimeStats(r.Context(), id)
+	if err != nil {
+		respondError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to load uptime stats")
+		return
+	}
+	out := dtoV1.MonitorUptimeStatsResponse{ResourceID: id, Stats: make([]dtoV1.MonitorUptimeStat, 0, len(stats))}
+	for _, s := range stats {
+		out.Stats = append(out.Stats, dtoV1.MonitorUptimeStat{
+			Hour: s.Hour, UptimePercent: s.UptimePercent, SuccessfulCount: s.SuccessfulCount, TotalCount: s.TotalCount,
+		})
+	}
+	respond(w, http.StatusOK, out)
+}
+
+// AddTag handles POST /api/v1/monitors/{id}/tags (spec 085 parity).
+//
+// @Summary     Attach tags to a monitor
+// @Tags        monitors
+// @Security    BearerAuth
+// @Accept      json
+// @Param       id   path string true "Monitor ID"
+// @Param       body body dtoV1.AddTagsRequest true "Tag IDs"
+// @Success     204
+// @Failure     403 {object} dtoV1.ErrorResponse
+// @Failure     404 {object} dtoV1.ErrorResponse
+// @Router      /monitors/{id}/tags [post]
+func (h *MonitorHandler) AddTag(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var req dtoV1.AddTagsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondError(w, r, http.StatusUnprocessableEntity, "VALIDATION_FAILED", "invalid request body")
+		return
+	}
+	if err := h.service.AddTagsToResource(r.Context(), id, req.TagIDs); err != nil {
+		if errors.Is(err, service.ErrResourceNotFound) {
+			respondError(w, r, http.StatusNotFound, "RESOURCE_NOT_FOUND", "monitor not found")
+			return
+		}
+		respondError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to attach tags")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// RemoveTag handles DELETE /api/v1/monitors/{id}/tags/{tagID} (spec 085 parity).
+//
+// @Summary     Detach a tag from a monitor
+// @Tags        monitors
+// @Security    BearerAuth
+// @Param       id    path string true "Monitor ID"
+// @Param       tagID path string true "Tag ID"
+// @Success     204
+// @Failure     403 {object} dtoV1.ErrorResponse
+// @Failure     404 {object} dtoV1.ErrorResponse
+// @Router      /monitors/{id}/tags/{tagID} [delete]
+func (h *MonitorHandler) RemoveTag(w http.ResponseWriter, r *http.Request) {
+	if err := h.service.RemoveTagFromResource(r.Context(), chi.URLParam(r, "id"), chi.URLParam(r, "tagID")); err != nil {
+		if errors.Is(err, service.ErrResourceNotFound) {
+			respondError(w, r, http.StatusNotFound, "RESOURCE_NOT_FOUND", "monitor or tag not found")
+			return
+		}
+		respondError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to detach tag")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // Delete handles DELETE /api/v1/monitors/{id}

--- a/internal/api/handler/v1/monitor_handler_test.go
+++ b/internal/api/handler/v1/monitor_handler_test.go
@@ -34,15 +34,19 @@ type problemDetailResponse struct {
 // --- mock service ---
 
 type mockMonitorService struct {
-	resources []*domain.Resource
-	resource  *domain.Resource
-	listErr   error
-	getErr    error
-	createErr error
-	updateErr error
-	deleteErr error
-	pauseErr  error
-	resumeErr error
+	resources    []*domain.Resource
+	resource     *domain.Resource
+	listErr      error
+	getErr       error
+	createErr    error
+	updateErr    error
+	deleteErr    error
+	pauseErr     error
+	resumeErr    error
+	addTagsErr   error
+	removeTagErr error
+	lastUpdate   *dto.UpdateResourcePayload // captured by UpdateResource (spec 085 PATCH test)
+	lastTagIDs   []string                   // captured by AddTagsToResource
 }
 
 func (m *mockMonitorService) ListActiveResources(_ context.Context, limit, offset int) ([]*domain.Resource, error) {
@@ -109,11 +113,21 @@ func (m *mockMonitorService) CreateResource(_ context.Context, payload *dto.Crea
 	}, nil
 }
 
-func (m *mockMonitorService) UpdateResource(_ context.Context, id string, _ *dto.UpdateResourcePayload) (*domain.Resource, error) {
+func (m *mockMonitorService) UpdateResource(_ context.Context, id string, payload *dto.UpdateResourcePayload) (*domain.Resource, error) {
+	m.lastUpdate = payload
 	if m.updateErr != nil {
 		return nil, m.updateErr
 	}
 	return &domain.Resource{Base: domain.Base{ID: id, CreatedAt: time.Now(), UpdatedAt: time.Now()}}, nil
+}
+
+func (m *mockMonitorService) AddTagsToResource(_ context.Context, _ string, tagIDs []string) error {
+	m.lastTagIDs = tagIDs
+	return m.addTagsErr
+}
+
+func (m *mockMonitorService) RemoveTagFromResource(_ context.Context, _, _ string) error {
+	return m.removeTagErr
 }
 
 func (m *mockMonitorService) DeleteResource(_ context.Context, _ string) error {
@@ -132,7 +146,7 @@ func (m *mockMonitorService) ResumeMonitoring(_ context.Context, _ string) error
 
 func newMonitorRouter(svc v1.MonitorV1ServiceInterface) *chi.Mux {
 	r := chi.NewRouter()
-	h := v1.NewMonitorHandler(svc)
+	h := v1.NewMonitorHandler(svc, nil, nil)
 	r.Get("/api/v1/monitors", h.List)
 	r.With(middleware.RequireReadWrite).Post("/api/v1/monitors", h.Create)
 	r.Get("/api/v1/monitors/{id}", h.Get)
@@ -140,6 +154,10 @@ func newMonitorRouter(svc v1.MonitorV1ServiceInterface) *chi.Mux {
 	r.With(middleware.RequireReadWrite).Delete("/api/v1/monitors/{id}", h.Delete)
 	r.With(middleware.RequireReadWrite).Post("/api/v1/monitors/{id}/pause", h.Pause)
 	r.With(middleware.RequireReadWrite).Post("/api/v1/monitors/{id}/resume", h.Resume)
+	// spec 085 parity write routes (live/uptime reads need stubs — see monitor_parity_test.go)
+	r.With(middleware.RequireReadWrite).Patch("/api/v1/monitors/{id}", h.Patch)
+	r.With(middleware.RequireReadWrite).Post("/api/v1/monitors/{id}/tags", h.AddTag)
+	r.With(middleware.RequireReadWrite).Delete("/api/v1/monitors/{id}/tags/{tagID}", h.RemoveTag)
 	return r
 }
 
@@ -175,6 +193,9 @@ func TestMonitorHandler_ScopeEnforcement_ReadKeyOnWriteRoutes_Returns403(t *test
 		{"DELETE", "/api/v1/monitors/abc", nil},
 		{"POST", "/api/v1/monitors/abc/pause", nil},
 		{"POST", "/api/v1/monitors/abc/resume", nil},
+		{"PATCH", "/api/v1/monitors/abc", []byte(`{"name":"x"}`)},
+		{"POST", "/api/v1/monitors/abc/tags", []byte(`{"tag_ids":["t1"]}`)},
+		{"DELETE", "/api/v1/monitors/abc/tags/t1", nil},
 	}
 
 	for _, tc := range writeCases {

--- a/internal/api/handler/v1/monitor_parity_test.go
+++ b/internal/api/handler/v1/monitor_parity_test.go
@@ -1,0 +1,114 @@
+package v1_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	v1 "github.com/denisakp/ogoune/internal/api/handler/v1"
+	"github.com/denisakp/ogoune/internal/dto"
+	dtoV1 "github.com/denisakp/ogoune/internal/dto/v1"
+	"github.com/denisakp/ogoune/internal/service"
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type liveStub struct {
+	resp *dto.LiveSnapshotResponse
+	err  error
+}
+
+func (s *liveStub) GetLiveSnapshot(_ context.Context, _ string) (*dto.LiveSnapshotResponse, error) {
+	return s.resp, s.err
+}
+
+type uptimeStub struct {
+	rows []dto.UptimeStatResponse
+	err  error
+}
+
+func (s *uptimeStub) GetUptimeStats(_ context.Context, _ string) ([]dto.UptimeStatResponse, error) {
+	return s.rows, s.err
+}
+
+func newParityRouter(svc v1.MonitorV1ServiceInterface, live *liveStub, up *uptimeStub) *chi.Mux {
+	h := v1.NewMonitorHandler(svc, live, up)
+	r := chi.NewRouter()
+	r.Get("/api/v1/monitors/{id}/live", h.GetLive)
+	r.Get("/api/v1/monitors/{id}/uptime-stats", h.GetUptimeStats)
+	r.Post("/api/v1/monitors/{id}/tags", h.AddTag)
+	r.Delete("/api/v1/monitors/{id}/tags/{tagID}", h.RemoveTag)
+	r.Patch("/api/v1/monitors/{id}", h.Patch)
+	return r
+}
+
+func doReq(router *chi.Mux, method, path string, body []byte) *httptest.ResponseRecorder {
+	var rd *bytes.Reader
+	if body != nil {
+		rd = bytes.NewReader(body)
+	} else {
+		rd = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(method, path, rd)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestMonitorParity_Live(t *testing.T) {
+	router := newParityRouter(&mockMonitorService{}, &liveStub{resp: &dto.LiveSnapshotResponse{}}, &uptimeStub{})
+	rr := doReq(router, http.MethodGet, "/api/v1/monitors/m1/live", nil)
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	router404 := newParityRouter(&mockMonitorService{}, &liveStub{err: service.ErrResourceNotFound}, &uptimeStub{})
+	rr = doReq(router404, http.MethodGet, "/api/v1/monitors/missing/live", nil)
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestMonitorParity_UptimeStats(t *testing.T) {
+	router := newParityRouter(&mockMonitorService{}, &liveStub{}, &uptimeStub{rows: []dto.UptimeStatResponse{
+		{UptimePercent: 99.9, SuccessfulCount: 10, TotalCount: 10},
+		{UptimePercent: 50, SuccessfulCount: 1, TotalCount: 2},
+	}})
+	rr := doReq(router, http.MethodGet, "/api/v1/monitors/m1/uptime-stats", nil)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var body struct {
+		Data dtoV1.MonitorUptimeStatsResponse `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(t, "m1", body.Data.ResourceID)
+	assert.Len(t, body.Data.Stats, 2)
+	assert.Equal(t, 99.9, body.Data.Stats[0].UptimePercent)
+}
+
+func TestMonitorParity_TagsAdd204AndCaptures(t *testing.T) {
+	svc := &mockMonitorService{}
+	router := newParityRouter(svc, &liveStub{}, &uptimeStub{})
+	rr := doReq(router, http.MethodPost, "/api/v1/monitors/m1/tags", []byte(`{"tag_ids":["t1","t2"]}`))
+	assert.Equal(t, http.StatusNoContent, rr.Code)
+	assert.Equal(t, []string{"t1", "t2"}, svc.lastTagIDs)
+}
+
+func TestMonitorParity_TagRemove204(t *testing.T) {
+	router := newParityRouter(&mockMonitorService{}, &liveStub{}, &uptimeStub{})
+	rr := doReq(router, http.MethodDelete, "/api/v1/monitors/m1/tags/t1", nil)
+	assert.Equal(t, http.StatusNoContent, rr.Code)
+}
+
+func TestMonitorParity_PatchIsPartial(t *testing.T) {
+	svc := &mockMonitorService{}
+	router := newParityRouter(svc, &liveStub{}, &uptimeStub{})
+	rr := doReq(router, http.MethodPatch, "/api/v1/monitors/m1", []byte(`{"name":"renamed only"}`))
+	require.Equal(t, http.StatusOK, rr.Code)
+	// only the sent field is set in the partial payload; others stay nil (unset ⇒ preserved).
+	require.NotNil(t, svc.lastUpdate)
+	require.NotNil(t, svc.lastUpdate.Name)
+	assert.Equal(t, "renamed only", *svc.lastUpdate.Name)
+	assert.Nil(t, svc.lastUpdate.Interval, "unsent field must be nil (preserved)")
+	assert.Nil(t, svc.lastUpdate.Target)
+}

--- a/internal/api/handler/v1/resource_credential_handler.go
+++ b/internal/api/handler/v1/resource_credential_handler.go
@@ -68,7 +68,7 @@ func mapCredentialResponse(c *domain.ResourceCredential) dtoV1.CredentialRespons
 // @Param    id path string true "Resource ID"
 // @Success  200 {object} dtoV1.SingleResponse[dtoV1.CredentialResponse]
 // @Failure  404 {object} dtoV1.ErrorResponse
-// @Router   /resources/{id}/credentials [get]
+// @Router   /monitors/{id}/credentials [get]
 func (h *ResourceCredentialHandler) Get(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	cred, err := h.service.Get(r.Context(), id)
@@ -100,7 +100,7 @@ func (h *ResourceCredentialHandler) Get(w http.ResponseWriter, r *http.Request) 
 // @Failure  403 {object} dtoV1.ErrorResponse
 // @Failure  404 {object} dtoV1.ErrorResponse
 // @Failure  422 {object} dtoV1.ErrorResponse
-// @Router   /resources/{id}/credentials [post]
+// @Router   /monitors/{id}/credentials [post]
 func (h *ResourceCredentialHandler) Set(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	req, ok := decodeCredentialBody(w, r)
@@ -150,7 +150,7 @@ func (h *ResourceCredentialHandler) Set(w http.ResponseWriter, r *http.Request) 
 // @Param    id path string true "Resource ID"
 // @Success  204
 // @Failure  404 {object} dtoV1.ErrorResponse
-// @Router   /resources/{id}/credentials [delete]
+// @Router   /monitors/{id}/credentials [delete]
 func (h *ResourceCredentialHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	err := h.service.Delete(r.Context(), id)
@@ -183,7 +183,7 @@ func (h *ResourceCredentialHandler) Delete(w http.ResponseWriter, r *http.Reques
 // @Failure  404 {object} dtoV1.ErrorResponse
 // @Failure  422 {object} dtoV1.ErrorResponse
 // @Failure  429 {object} dtoV1.ErrorResponse
-// @Router   /resources/{id}/credentials/test [post]
+// @Router   /monitors/{id}/credentials/test [post]
 func (h *ResourceCredentialHandler) Test(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	req, ok := decodeCredentialBody(w, r)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -330,6 +330,17 @@ func NewRouter(
 				// Monitor↔host link. Write-scoped.
 				r.With(middleware.RequireReadWrite).Post("/{id}/host", hostV1Handler.LinkMonitor)
 				r.With(middleware.RequireReadWrite).Delete("/{id}/host", hostV1Handler.UnlinkMonitor)
+				// Root→v1 parity additions (spec 085). Additive; reads open, writes scoped.
+				r.Get("/{id}/live", monitorV1Handler.GetLive)
+				r.Get("/{id}/uptime-stats", monitorV1Handler.GetUptimeStats)
+				r.With(middleware.RequireReadWrite).Patch("/{id}", monitorV1Handler.Patch)
+				r.With(middleware.RequireReadWrite).Post("/{id}/tags", monitorV1Handler.AddTag)
+				r.With(middleware.RequireReadWrite).Delete("/{id}/tags/{tagID}", monitorV1Handler.RemoveTag)
+				// Resource credentials re-mounted under v1 (spec 085). Same handler as root.
+				r.Get(routeCredentials, credentialV1Handler.Get)
+				r.With(middleware.RequireReadWrite).Post(routeCredentials, credentialV1Handler.Set)
+				r.With(middleware.RequireReadWrite).Delete(routeCredentials, credentialV1Handler.Delete)
+				r.With(middleware.RequireReadWrite).With(middleware.PerUserRateLimit(10)).Post(routeCredentialsTest, credentialV1Handler.Test)
 			})
 			// Hosts — agent device monitoring. Read GET; writes scoped.
 			r.Route("/hosts", func(r chi.Router) {

--- a/internal/dto/v1/monitor_parity.go
+++ b/internal/dto/v1/monitor_parity.go
@@ -1,0 +1,25 @@
+package v1
+
+import "time"
+
+// AddTagsRequest is the body for POST /api/v1/monitors/{id}/tags (spec 085).
+// @name AddTagsRequest
+type AddTagsRequest struct {
+	TagIDs []string `json:"tag_ids"`
+}
+
+// MonitorUptimeStat is one hourly uptime bucket.
+// @name MonitorUptimeStat
+type MonitorUptimeStat struct {
+	Hour            time.Time `json:"hour"`
+	UptimePercent   float64   `json:"uptime_percent"`
+	SuccessfulCount int       `json:"successful_count"`
+	TotalCount      int       `json:"total_count"`
+}
+
+// MonitorUptimeStatsResponse is the payload of GET /api/v1/monitors/{id}/uptime-stats.
+// @name MonitorUptimeStatsResponse
+type MonitorUptimeStatsResponse struct {
+	ResourceID string              `json:"resource_id"`
+	Stats      []MonitorUptimeStat `json:"stats"`
+}

--- a/internal/platform/bootstrap/router.go
+++ b/internal/platform/bootstrap/router.go
@@ -69,7 +69,7 @@ func InitRouter(app *App) {
 	componentHandler := handler.NewComponentHandler(app.ComponentService)
 
 	// V1 handlers
-	monitorV1Handler := v1handler.NewMonitorHandler(app.ResourceService)
+	monitorV1Handler := v1handler.NewMonitorHandler(app.ResourceService, liveSnapshotService, activityService)
 	incidentV1Handler := v1handler.NewIncidentHandler(incidentAPIService)
 	searchV1Handler := v1handler.NewSearchHandler(service.NewSearchService(app.ResourceRepo, app.IncidentRepo))
 	channelV1Handler := v1handler.NewNotificationChannelHandler(notificationService)

--- a/web/packages/api-types/generated/schema.d.ts
+++ b/web/packages/api-types/generated/schema.d.ts
@@ -1540,6 +1540,274 @@ export interface paths {
         };
         options?: never;
         head?: never;
+        /** Partially update a monitor */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Monitor ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            /** @description Partial update payload */
+            requestBody: {
+                content: {
+                    "application/json": Record<string, never> | components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.UpdateMonitorRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse"];
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+                /** @description Unprocessable Entity */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/monitors/{id}/credentials": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the credential metadata for a resource (password masked) */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Resource ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        /** Create or replace credentials for a resource */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Resource ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            /** @description Credential payload */
+            requestBody: {
+                content: {
+                    "application/json": Record<string, never> | components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.CredentialCreateRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse"];
+                    };
+                };
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse"];
+                    };
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+                /** @description Unprocessable Entity */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        /** Remove credentials for a resource (revert to no-auth behavior) */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Resource ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/monitors/{id}/credentials/test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Live-test credentials without persisting (rate-limited 10/min) */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Resource ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            /** @description Credential payload (not persisted) */
+            requestBody: {
+                content: {
+                    "application/json": Record<string, never> | components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.CredentialCreateRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.CredentialTestResponse"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+                /** @description Unprocessable Entity */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+                /** @description Too Many Requests */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
         patch?: never;
         trace?: never;
     };
@@ -1639,6 +1907,54 @@ export interface paths {
                 };
             };
         };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/monitors/{id}/live": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Live snapshot of a monitor */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Monitor ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_LiveSnapshotResponse"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -1752,6 +2068,171 @@ export interface paths {
                 };
             };
         };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/monitors/{id}/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Attach tags to a monitor */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Monitor ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            /** @description Tag IDs */
+            requestBody: {
+                content: {
+                    "application/json": Record<string, never> | components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.AddTagsRequest"];
+                };
+            };
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/monitors/{id}/tags/{tagID}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Detach a tag from a monitor */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Monitor ID */
+                    id: string;
+                    /** @description Tag ID */
+                    tagID: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Forbidden */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/monitors/{id}/uptime-stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Hourly uptime statistics for a monitor */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Monitor ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorUptimeStatsResponse"];
+                    };
+                };
+                /** @description Not Found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -2421,219 +2902,6 @@ export interface paths {
             };
         };
         post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/resources/{id}/credentials": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get the credential metadata for a resource (password masked) */
-        get: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Resource ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse"];
-                    };
-                };
-                /** @description Not Found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
-                    };
-                };
-            };
-        };
-        put?: never;
-        /** Create or replace credentials for a resource */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Resource ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            /** @description Credential payload */
-            requestBody: {
-                content: {
-                    "application/json": Record<string, never> | components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.CredentialCreateRequest"];
-                };
-            };
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse"];
-                    };
-                };
-                /** @description Created */
-                201: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_CredentialResponse"];
-                    };
-                };
-                /** @description Forbidden */
-                403: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
-                    };
-                };
-                /** @description Not Found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
-                    };
-                };
-                /** @description Unprocessable Entity */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
-                    };
-                };
-            };
-        };
-        /** Remove credentials for a resource (revert to no-auth behavior) */
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Resource ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: {
-                /** @description No Content */
-                204: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Not Found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
-                    };
-                };
-            };
-        };
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/resources/{id}/credentials/test": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Live-test credentials without persisting (rate-limited 10/min) */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    /** @description Resource ID */
-                    id: string;
-                };
-                cookie?: never;
-            };
-            /** @description Credential payload (not persisted) */
-            requestBody: {
-                content: {
-                    "application/json": Record<string, never> | components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.CredentialCreateRequest"];
-                };
-            };
-            responses: {
-                /** @description OK */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.CredentialTestResponse"];
-                    };
-                };
-                /** @description Not Found */
-                404: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
-                    };
-                };
-                /** @description Unprocessable Entity */
-                422: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
-                    };
-                };
-                /** @description Too Many Requests */
-                429: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.ErrorResponse"];
-                    };
-                };
-            };
-        };
         delete?: never;
         options?: never;
         head?: never;
@@ -3523,6 +3791,221 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        "github_com_denisakp_ogoune_internal_domain.Component": {
+            created_at?: string;
+            description?: string;
+            grouping_window_seconds?: number;
+            id?: string;
+            last_notification_status?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.ComponentStatus"];
+            name?: string;
+            resources?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.Resource"][];
+            updated_at?: string;
+        };
+        /** @enum {string} */
+        "github_com_denisakp_ogoune_internal_domain.ComponentStatus": "up" | "degraded" | "down";
+        "github_com_denisakp_ogoune_internal_domain.Incident": {
+            cause?: string;
+            created_at?: string;
+            details?: number[];
+            diagnostics?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.IncidentDiagnostics"];
+            event_steps?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.IncidentEventStep"][];
+            id?: string;
+            /** @description nil = active, timestamp = resolved */
+            resolved_at?: string;
+            resource?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.Resource"];
+            resource_id?: string;
+            started_at?: string;
+            updated_at?: string;
+        };
+        "github_com_denisakp_ogoune_internal_domain.IncidentDiagnostics": {
+            /** @description true if response body is base64 encoded */
+            body_encoded?: boolean;
+            /** @description true if response body was truncated */
+            body_truncated?: boolean;
+            created_at?: string;
+            /** @description Milliseconds (0 if not measured) */
+            dns_duration?: number;
+            /** @description Machine-readable error from Go */
+            error_message?: string;
+            /** @description Human-friendly explanation */
+            error_summary?: string;
+            /** @description e.g., connection_timeout, invalid_status_code */
+            failure_type?: string;
+            /** @description Milliseconds (0 if body not captured) */
+            first_byte_duration?: number;
+            /** @description HTTP status code (-1 if N/A) */
+            http_status_code?: number;
+            /** @description ICMP enrichment fields (H2: populated by diagnostic enricher for all DOWN incidents) */
+            icmp_available?: boolean;
+            /** @description whether host replied to ICMP echo */
+            icmp_reachable?: boolean;
+            /** @description round-trip time in ms; null when unreachable */
+            icmp_rtt_ms?: number;
+            id?: string;
+            incident?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.Incident"];
+            incident_id?: string;
+            /** @description Keyword enrichment fields (populated for keyword monitor incidents only) */
+            keyword?: string;
+            keyword_found?: boolean;
+            keyword_mode?: string;
+            /** @description Sanitized request headers */
+            request_headers?: {
+                [key: string]: string;
+            };
+            /** @description GET, HEAD, POST, etc. */
+            request_method?: string;
+            /** @description Timeout in seconds */
+            request_timeout?: number;
+            /** @description Full URL being checked */
+            request_url?: string;
+            /** @description Base64 encoded if needed, truncated to 5KB */
+            response_body?: string;
+            /** @description Response headers */
+            response_headers?: {
+                [key: string]: string;
+            };
+            /** @description Actual response size in bytes */
+            response_size?: number;
+            /** @description enum: icmp_unavailable|host_unreachable|service_down|"" */
+            root_cause_hint?: string;
+            /** @description Milliseconds (0 if not applicable) */
+            tls_duration?: number;
+            /** @description Milliseconds */
+            total_duration?: number;
+            updated_at?: string;
+        };
+        "github_com_denisakp_ogoune_internal_domain.IncidentEventStep": {
+            created_at?: string;
+            id?: string;
+            incident?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.Incident"];
+            incident_id?: string;
+            message?: string;
+            step?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.IncidentEventStepType"];
+            updated_at?: string;
+        };
+        /** @enum {string} */
+        "github_com_denisakp_ogoune_internal_domain.IncidentEventStepType": "detected" | "resolved" | "alert_sent" | "resource_down_alert" | "resource_up_alert" | "flapping" | "flapping_stabilized" | "reminder" | "component_alert";
+        "github_com_denisakp_ogoune_internal_domain.MonitoringActivity": {
+            created_at?: string;
+            id?: string;
+            is_maintenance?: boolean;
+            message?: string;
+            resource?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.Resource"];
+            resource_id?: string;
+            response_data?: number[];
+            response_time?: number;
+            success?: boolean;
+            updated_at?: string;
+        };
+        "github_com_denisakp_ogoune_internal_domain.NotificationChannel": {
+            /** @description JSON configuration specific to channel type */
+            config?: number[];
+            created_at?: string;
+            enabled_by_default?: boolean;
+            failures_24h?: number;
+            id?: string;
+            last_failure_at?: string;
+            last_sent_at?: string;
+            name?: string;
+            type?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.NotificationChannelType"];
+            updated_at?: string;
+        };
+        /** @enum {string} */
+        "github_com_denisakp_ogoune_internal_domain.NotificationChannelType": "smtp" | "slack" | "sms";
+        "github_com_denisakp_ogoune_internal_domain.Resource": {
+            component?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.Component"];
+            component_id?: string;
+            confirmation_checks?: number;
+            confirmation_interval?: number;
+            created_at?: string;
+            credential?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.ResourceCredential"];
+            expiry_alert_thresholds?: string;
+            failure_count?: number;
+            flap_detection_enabled?: boolean;
+            flap_max_duration_minutes?: number;
+            flap_started_at?: string;
+            flap_threshold?: number;
+            flap_window_seconds?: number;
+            heartbeat_grace?: number;
+            heartbeat_interval?: number;
+            heartbeat_slug?: string;
+            /** @description optional link to a monitored host */
+            host_id?: string;
+            id?: string;
+            incident_count_30d?: number;
+            incidents?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.Incident"][];
+            /** @description in seconds */
+            interval?: number;
+            is_active?: boolean;
+            keyword?: string;
+            keyword_mode?: string;
+            last_checked?: string;
+            last_ping_at?: string;
+            last_status_transition?: string;
+            metadata?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.ResourceMetaData"];
+            metadata_pending?: boolean;
+            name?: string;
+            notification_channels?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.NotificationChannel"][];
+            protocol_port?: number;
+            protocol_type?: string;
+            reminder_interval_minutes?: number;
+            response_time?: number;
+            status?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.ResourceStatus"];
+            tags?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.Tags"][];
+            target?: string;
+            /** @description in seconds */
+            timeout?: number;
+            type?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.ResourceType"];
+            updated_at?: string;
+            uptime_7d?: number;
+            uptime_30d?: number;
+        };
+        "github_com_denisakp_ogoune_internal_domain.ResourceCredential": {
+            created_at?: string;
+            id?: string;
+            resource_id?: string;
+            updated_at?: string;
+            username?: string;
+        };
+        "github_com_denisakp_ogoune_internal_domain.ResourceMetaData": {
+            domain_expiration_date?: string;
+            domain_registrar?: string;
+            ssl_expiration_date?: string;
+            ssl_issuer?: string;
+        };
+        /** @enum {string} */
+        "github_com_denisakp_ogoune_internal_domain.ResourceStatus": "up" | "down" | "error" | "unknown" | "paused" | "pending" | "warning" | "flapping";
+        /** @enum {string} */
+        "github_com_denisakp_ogoune_internal_domain.ResourceType": "http" | "tcp" | "dns" | "icmp" | "heartbeat" | "keyword" | "protocol";
+        "github_com_denisakp_ogoune_internal_domain.Tags": {
+            color?: string;
+            created_at?: string;
+            description?: string;
+            id?: string;
+            name?: string;
+            resources?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.Resource"][];
+            updated_at?: string;
+        };
+        "github_com_denisakp_ogoune_internal_dto.LiveActiveIncident": {
+            cause?: string;
+            id?: string;
+            started_at?: string;
+        };
+        "github_com_denisakp_ogoune_internal_dto.LiveSnapshotResponse": {
+            active_incident?: components["schemas"]["github_com_denisakp_ogoune_internal_dto.LiveActiveIncident"];
+            fetched_at?: string;
+            recent_activities?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.MonitoringActivity"][];
+            resource?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.Resource"];
+            stats?: components["schemas"]["github_com_denisakp_ogoune_internal_dto.LiveStats"];
+        };
+        "github_com_denisakp_ogoune_internal_dto.LiveStats": {
+            avg_response_time_24h?: number;
+            last_response_time?: number;
+            uptime_24h?: number;
+            uptime_2h?: number;
+            uptime_7d?: number;
+            uptime_30d?: number;
+        };
         "github_com_denisakp_ogoune_internal_dto.ProblemDetail": {
             code?: string;
             detail?: string;
@@ -3648,6 +4131,9 @@ export interface components {
         "github_com_denisakp_ogoune_internal_dto.PublicWindowStats": {
             incidents?: number;
             uptime_ratio?: number;
+        };
+        "github_com_denisakp_ogoune_internal_dto_v1.AddTagsRequest": {
+            tag_ids?: string[];
         };
         "github_com_denisakp_ogoune_internal_dto_v1.AnnouncementResponse": {
             createdAt?: string;
@@ -3862,6 +4348,16 @@ export interface components {
             type?: string;
             updated_at?: string;
         };
+        "github_com_denisakp_ogoune_internal_dto_v1.MonitorUptimeStat": {
+            hour?: string;
+            successful_count?: number;
+            total_count?: number;
+            uptime_percent?: number;
+        };
+        "github_com_denisakp_ogoune_internal_dto_v1.MonitorUptimeStatsResponse": {
+            resource_id?: string;
+            stats?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.MonitorUptimeStat"][];
+        };
         "github_com_denisakp_ogoune_internal_dto_v1.PortResult": {
             banner?: string;
             port?: number;
@@ -3964,6 +4460,10 @@ export interface components {
             /** @description Meta is short context (e.g. a monitor's target), omitted when empty. */
             meta?: string;
         };
+        "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_LiveSnapshotResponse": {
+            data?: components["schemas"]["github_com_denisakp_ogoune_internal_dto.LiveSnapshotResponse"];
+            meta?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.MetaResponse"];
+        };
         "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_AnnouncementResponse": {
             data?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.AnnouncementResponse"];
             meta?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.MetaResponse"];
@@ -4014,6 +4514,10 @@ export interface components {
         };
         "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse": {
             data?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.MonitorResponse"];
+            meta?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.MetaResponse"];
+        };
+        "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorUptimeStatsResponse": {
+            data?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.MonitorUptimeStatsResponse"];
             meta?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.MetaResponse"];
         };
         "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_PortScanResponse": {


### PR DESCRIPTION
## Spec 085 — Resources root→v1 migration, **Phase 1 (parity)**

Bring `/api/v1/monitors` to full parity with the frozen root `/api/resources` so the versioned API can become the single source of truth. **Additive, backend-only, zero migration, nothing removed** — every new endpoint reuses the *same service* the root handler already calls. Full speckit cycle (specify → clarify → plan → tasks → analyze → implement).

### Added under `/api/v1/monitors`
| Endpoint | Reuses | Scope |
|---|---|---|
| `GET /{id}/live` | `LiveSnapshotService.GetLiveSnapshot` | read |
| `GET /{id}/uptime-stats` | `MonitoringActivityService.GetUptimeStats` | read |
| `POST /{id}/tags` → **204** · `DELETE /{id}/tags/{tagID}` → **204** | `ResourceService` tag methods | read_write |
| `PATCH /{id}` (partial; `PUT` retained) | the existing v1 `Update` body (already pointer/partial) | read_write |
| `/{id}/credentials*` | the **already-v1** credential handler, re-mounted under v1 (`@Router` moved `/resources`→`/monitors`; root mount kept — additive) | read/read_write |

### Design
- `MonitorV1ServiceInterface` widened with `AddTagsToResource`/`RemoveTagFromResource` (already on `app.ResourceService`); `MonitorHandler` gains injected live + uptime providers (bootstrap wires the existing services). No new service logic, **no migration, no domain change**.
- PATCH was essentially free — `UpdateMonitorRequest` is already PATCH-shaped and the v1 update builds a partial payload; only the verb/route was added.

### Clarified decisions
**Phase 1 only** this chantier · **add PATCH** to v1 · tags **204** · Phase-2 cutover = **hard-switch** (recorded for the follow-up).

### Tests
- Parity units: live 200/404, uptime-stats shape, tags 204 + captured ids, PATCH partial-payload (only sent field set, others nil = preserved).
- The 3 new write routes added to the scope-enforcement table (read key → **403**, read_write → not-403).
- Existing root + v1 monitor suites unaffected. OpenAPI + fe-types regenerated + committed (`/monitors/{id}` now has get/put/patch/delete; credentials moved off `/resources`). `go test -race` + `make ci-local` green.

> **Deferred (US2 / Phase 2)**: frontend `resourceService` repoint via a `mapMonitorToResource` mapping layer (keeps the `Resource` type + 25 consumers unchanged) + delete the root handler/routes + trim `NewRouter`. Separate, gated chantier.