### PR TITLE
feat(api): v1 monitors return the rich resource shape (spec 085 Phase 2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **v1 monitors return the rich resource shape (spec 085, Phase 2a)** — `/api/v1/monitors`
+  List/Get/Create/Update/PATCH/Pause/Resume now return the same enriched `ResourceResponse`
+  the root `/api/resources` returns (tags as objects, `last_checked`, `uptime_7d`,
+  `incident_count_30d`, `response_times`, `expiry_status`, `waiting`, SSL/domain
+  days-remaining, all monitor-type fields) and accept the full create/update payloads (no
+  dropped fields), reusing the root's mapping + service. This supersedes the thin
+  `MonitorResponse` for CRUD (kept only for the monitor↔host link endpoints). Prerequisite
+  for the frontend repoint + root-handler deletion (Phase 2b, still pending). Contract
+  change is safe: beta, and the SPA is the only v1 consumer.
+
 ### Added
 
 - **Monitors API parity with the root resources API (spec 085, Phase 1)** — additive

--- a/api/openapi/v1.json
+++ b/api/openapi/v1.json
@@ -47,6 +47,21 @@
                     "ComponentStatusDown"
                 ]
             },
+            "github_com_denisakp_ogoune_internal_domain.ExpiryStatus": {
+                "enum": [
+                    "ok",
+                    "warning",
+                    "critical",
+                    "expired"
+                ],
+                "type": "string",
+                "x-enum-varnames": [
+                    "ExpiryStatusOK",
+                    "ExpiryStatusWarning",
+                    "ExpiryStatusCritical",
+                    "ExpiryStatusExpired"
+                ]
+            },
             "github_com_denisakp_ogoune_internal_domain.Incident": {
                 "properties": {
                     "cause": {
@@ -617,6 +632,98 @@
                 },
                 "type": "object"
             },
+            "github_com_denisakp_ogoune_internal_dto.CreateResourcePayload": {
+                "properties": {
+                    "component_id": {
+                        "type": "string"
+                    },
+                    "confirmation_checks": {
+                        "type": "integer"
+                    },
+                    "confirmation_interval": {
+                        "type": "integer"
+                    },
+                    "expiry_alert_thresholds": {
+                        "type": "string"
+                    },
+                    "flap_detection_enabled": {
+                        "type": "boolean"
+                    },
+                    "flap_max_duration_minutes": {
+                        "type": "integer"
+                    },
+                    "flap_threshold": {
+                        "type": "integer"
+                    },
+                    "flap_window_seconds": {
+                        "type": "integer"
+                    },
+                    "heartbeat_grace": {
+                        "type": "integer"
+                    },
+                    "heartbeat_interval": {
+                        "type": "integer"
+                    },
+                    "interval": {
+                        "maximum": 3600,
+                        "minimum": 10,
+                        "type": "integer"
+                    },
+                    "keyword": {
+                        "type": "string"
+                    },
+                    "keyword_mode": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "notification_channel_names": {
+                        "description": "NotificationChannelNames are channel names to attach; resolved to IDs at create time.\nChannels must already exist (they hold secrets and are never created here). Used by the\nbulk import path; missing name is a validation error.",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "protocol_port": {
+                        "type": "integer"
+                    },
+                    "protocol_type": {
+                        "type": "string"
+                    },
+                    "reminder_interval_minutes": {
+                        "type": "integer"
+                    },
+                    "tags": {
+                        "description": "Tag names - will be created if they don't exist",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "target": {
+                        "type": "string"
+                    },
+                    "timeout": {
+                        "maximum": 60,
+                        "minimum": 1,
+                        "type": "integer"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceType"
+                    }
+                },
+                "required": [
+                    "interval",
+                    "name",
+                    "target",
+                    "timeout",
+                    "type"
+                ],
+                "type": "object"
+            },
             "github_com_denisakp_ogoune_internal_dto.LiveActiveIncident": {
                 "properties": {
                     "cause": {
@@ -1105,6 +1212,279 @@
                 },
                 "type": "object"
             },
+            "github_com_denisakp_ogoune_internal_dto.ResourceMetaDataResponse": {
+                "properties": {
+                    "domain_days_remaining": {
+                        "type": "integer"
+                    },
+                    "domain_expiration_date": {
+                        "type": "string"
+                    },
+                    "domain_registrar": {
+                        "type": "string"
+                    },
+                    "ssl_days_remaining": {
+                        "type": "integer"
+                    },
+                    "ssl_expiration_date": {
+                        "type": "string"
+                    },
+                    "ssl_issuer": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_dto.ResourceResponse": {
+                "properties": {
+                    "component": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.Component"
+                    },
+                    "component_id": {
+                        "type": "string"
+                    },
+                    "confirmation_checks": {
+                        "type": "integer"
+                    },
+                    "confirmation_interval": {
+                        "type": "integer"
+                    },
+                    "created_at": {
+                        "type": "string"
+                    },
+                    "credential": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceCredential"
+                    },
+                    "expiry_alert_thresholds": {
+                        "type": "string"
+                    },
+                    "expiry_status": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.ExpiryStatus"
+                    },
+                    "failure_count": {
+                        "type": "integer"
+                    },
+                    "flap_detection_enabled": {
+                        "type": "boolean"
+                    },
+                    "flap_max_duration_minutes": {
+                        "type": "integer"
+                    },
+                    "flap_started_at": {
+                        "type": "string"
+                    },
+                    "flap_threshold": {
+                        "type": "integer"
+                    },
+                    "flap_window_seconds": {
+                        "type": "integer"
+                    },
+                    "heartbeat_grace": {
+                        "type": "integer"
+                    },
+                    "heartbeat_interval": {
+                        "type": "integer"
+                    },
+                    "heartbeat_slug": {
+                        "type": "string"
+                    },
+                    "host_id": {
+                        "description": "optional link to a monitored host",
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string"
+                    },
+                    "incident_count_30d": {
+                        "type": "integer"
+                    },
+                    "incidents": {
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.Incident"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "interval": {
+                        "description": "in seconds",
+                        "type": "integer"
+                    },
+                    "is_active": {
+                        "type": "boolean"
+                    },
+                    "keyword": {
+                        "type": "string"
+                    },
+                    "keyword_mode": {
+                        "type": "string"
+                    },
+                    "last_checked": {
+                        "type": "string"
+                    },
+                    "last_ping_at": {
+                        "type": "string"
+                    },
+                    "last_status_transition": {
+                        "type": "string"
+                    },
+                    "metadata": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto.ResourceMetaDataResponse"
+                    },
+                    "metadata_pending": {
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "notification_channels": {
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.NotificationChannel"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "protocol_port": {
+                        "type": "integer"
+                    },
+                    "protocol_type": {
+                        "type": "string"
+                    },
+                    "reminder_interval_minutes": {
+                        "type": "integer"
+                    },
+                    "response_time": {
+                        "type": "integer"
+                    },
+                    "response_times": {
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto.ResponseTimePoint"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceStatus"
+                    },
+                    "tags": {
+                        "items": {
+                            "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.Tags"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "target": {
+                        "type": "string"
+                    },
+                    "timeout": {
+                        "description": "in seconds",
+                        "type": "integer"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceType"
+                    },
+                    "updated_at": {
+                        "type": "string"
+                    },
+                    "uptime_30d": {
+                        "type": "number"
+                    },
+                    "uptime_7d": {
+                        "type": "number"
+                    },
+                    "waiting": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_dto.ResponseTimePoint": {
+                "properties": {
+                    "response_time": {
+                        "description": "in milliseconds",
+                        "type": "integer"
+                    },
+                    "timestamp": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "github_com_denisakp_ogoune_internal_dto.UpdateResourcePayload": {
+                "properties": {
+                    "component_id": {
+                        "type": "string"
+                    },
+                    "confirmation_checks": {
+                        "type": "integer"
+                    },
+                    "confirmation_interval": {
+                        "type": "integer"
+                    },
+                    "expiry_alert_thresholds": {
+                        "type": "string"
+                    },
+                    "flap_detection_enabled": {
+                        "type": "boolean"
+                    },
+                    "flap_max_duration_minutes": {
+                        "type": "integer"
+                    },
+                    "flap_threshold": {
+                        "type": "integer"
+                    },
+                    "flap_window_seconds": {
+                        "type": "integer"
+                    },
+                    "heartbeat_grace": {
+                        "type": "integer"
+                    },
+                    "heartbeat_interval": {
+                        "type": "integer"
+                    },
+                    "interval": {
+                        "type": "integer"
+                    },
+                    "is_active": {
+                        "type": "boolean"
+                    },
+                    "keyword": {
+                        "type": "string"
+                    },
+                    "keyword_mode": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "protocol_port": {
+                        "type": "integer"
+                    },
+                    "protocol_type": {
+                        "type": "string"
+                    },
+                    "reminder_interval_minutes": {
+                        "type": "integer"
+                    },
+                    "tags": {
+                        "description": "Tag IDs (ULIDs) - must reference existing tags",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "uniqueItems": false
+                    },
+                    "target": {
+                        "type": "string"
+                    },
+                    "timeout": {
+                        "type": "integer"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceType"
+                    }
+                },
+                "type": "object"
+            },
             "github_com_denisakp_ogoune_internal_dto_v1.AddTagsRequest": {
                 "properties": {
                     "tag_ids": {
@@ -1276,45 +1656,6 @@
                         "type": "string"
                     },
                     "prefix": {
-                        "type": "string"
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_denisakp_ogoune_internal_dto_v1.CreateMonitorRequest": {
-                "properties": {
-                    "component_id": {
-                        "type": "string"
-                    },
-                    "interval": {
-                        "type": "integer"
-                    },
-                    "keyword": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "protocol_port": {
-                        "type": "integer"
-                    },
-                    "protocol_type": {
-                        "type": "string"
-                    },
-                    "tags": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
-                    },
-                    "target": {
-                        "type": "string"
-                    },
-                    "timeout": {
-                        "type": "integer"
-                    },
-                    "type": {
                         "type": "string"
                     }
                 },
@@ -2128,6 +2469,17 @@
                 },
                 "type": "object"
             },
+            "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse": {
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto.ResourceResponse"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MetaResponse"
+                    }
+                },
+                "type": "object"
+            },
             "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_AnnouncementResponse": {
                 "properties": {
                     "data": {
@@ -2448,45 +2800,6 @@
                         },
                         "type": "array",
                         "uniqueItems": false
-                    }
-                },
-                "type": "object"
-            },
-            "github_com_denisakp_ogoune_internal_dto_v1.UpdateMonitorRequest": {
-                "properties": {
-                    "component_id": {
-                        "type": "string"
-                    },
-                    "interval": {
-                        "type": "integer"
-                    },
-                    "keyword": {
-                        "type": "string"
-                    },
-                    "name": {
-                        "type": "string"
-                    },
-                    "protocol_port": {
-                        "type": "integer"
-                    },
-                    "protocol_type": {
-                        "type": "string"
-                    },
-                    "tags": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array",
-                        "uniqueItems": false
-                    },
-                    "target": {
-                        "type": "string"
-                    },
-                    "timeout": {
-                        "type": "integer"
-                    },
-                    "type": {
-                        "type": "string"
                     }
                 },
                 "type": "object"
@@ -4161,7 +4474,7 @@
                                         "type": "object"
                                     },
                                     {
-                                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.CreateMonitorRequest",
+                                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto.CreateResourcePayload",
                                         "summary": "body",
                                         "description": "Monitor payload"
                                     }
@@ -4177,7 +4490,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse"
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse"
                                 }
                             }
                         },
@@ -4390,6 +4703,14 @@
                         "schema": {
                             "type": "string"
                         }
+                    },
+                    {
+                        "description": "Number of recent response-time points to include (default 60)",
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer"
+                        }
                     }
                 ],
                 "responses": {
@@ -4397,7 +4718,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse"
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse"
                                 }
                             }
                         },
@@ -4445,7 +4766,7 @@
                                         "type": "object"
                                     },
                                     {
-                                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.UpdateMonitorRequest",
+                                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto.UpdateResourcePayload",
                                         "summary": "body",
                                         "description": "Partial update payload"
                                     }
@@ -4461,7 +4782,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse"
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse"
                                 }
                             }
                         },
@@ -4529,7 +4850,7 @@
                                         "type": "object"
                                     },
                                     {
-                                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.UpdateMonitorRequest",
+                                        "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto.UpdateResourcePayload",
                                         "summary": "body",
                                         "description": "Update payload"
                                     }
@@ -4545,7 +4866,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse"
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse"
                                 }
                             }
                         },
@@ -5033,7 +5354,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse"
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse"
                                 }
                             }
                         },
@@ -5089,7 +5410,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse"
+                                    "$ref": "#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse"
                                 }
                             }
                         },

--- a/api/openapi/v1.yaml
+++ b/api/openapi/v1.yaml
@@ -32,6 +32,18 @@ components:
       - ComponentStatusUp
       - ComponentStatusDegraded
       - ComponentStatusDown
+    github_com_denisakp_ogoune_internal_domain.ExpiryStatus:
+      enum:
+      - ok
+      - warning
+      - critical
+      - expired
+      type: string
+      x-enum-varnames:
+      - ExpiryStatusOK
+      - ExpiryStatusWarning
+      - ExpiryStatusCritical
+      - ExpiryStatusExpired
     github_com_denisakp_ogoune_internal_domain.Incident:
       properties:
         cause:
@@ -438,6 +450,74 @@ components:
         updated_at:
           type: string
       type: object
+    github_com_denisakp_ogoune_internal_dto.CreateResourcePayload:
+      properties:
+        component_id:
+          type: string
+        confirmation_checks:
+          type: integer
+        confirmation_interval:
+          type: integer
+        expiry_alert_thresholds:
+          type: string
+        flap_detection_enabled:
+          type: boolean
+        flap_max_duration_minutes:
+          type: integer
+        flap_threshold:
+          type: integer
+        flap_window_seconds:
+          type: integer
+        heartbeat_grace:
+          type: integer
+        heartbeat_interval:
+          type: integer
+        interval:
+          maximum: 3600
+          minimum: 10
+          type: integer
+        keyword:
+          type: string
+        keyword_mode:
+          type: string
+        name:
+          type: string
+        notification_channel_names:
+          description: |-
+            NotificationChannelNames are channel names to attach; resolved to IDs at create time.
+            Channels must already exist (they hold secrets and are never created here). Used by the
+            bulk import path; missing name is a validation error.
+          items:
+            type: string
+          type: array
+          uniqueItems: false
+        protocol_port:
+          type: integer
+        protocol_type:
+          type: string
+        reminder_interval_minutes:
+          type: integer
+        tags:
+          description: Tag names - will be created if they don't exist
+          items:
+            type: string
+          type: array
+          uniqueItems: false
+        target:
+          type: string
+        timeout:
+          maximum: 60
+          minimum: 1
+          type: integer
+        type:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceType'
+      required:
+      - interval
+      - name
+      - target
+      - timeout
+      - type
+      type: object
     github_com_denisakp_ogoune_internal_dto.LiveActiveIncident:
       properties:
         cause:
@@ -771,6 +851,190 @@ components:
         uptime_ratio:
           type: number
       type: object
+    github_com_denisakp_ogoune_internal_dto.ResourceMetaDataResponse:
+      properties:
+        domain_days_remaining:
+          type: integer
+        domain_expiration_date:
+          type: string
+        domain_registrar:
+          type: string
+        ssl_days_remaining:
+          type: integer
+        ssl_expiration_date:
+          type: string
+        ssl_issuer:
+          type: string
+      type: object
+    github_com_denisakp_ogoune_internal_dto.ResourceResponse:
+      properties:
+        component:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.Component'
+        component_id:
+          type: string
+        confirmation_checks:
+          type: integer
+        confirmation_interval:
+          type: integer
+        created_at:
+          type: string
+        credential:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceCredential'
+        expiry_alert_thresholds:
+          type: string
+        expiry_status:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.ExpiryStatus'
+        failure_count:
+          type: integer
+        flap_detection_enabled:
+          type: boolean
+        flap_max_duration_minutes:
+          type: integer
+        flap_started_at:
+          type: string
+        flap_threshold:
+          type: integer
+        flap_window_seconds:
+          type: integer
+        heartbeat_grace:
+          type: integer
+        heartbeat_interval:
+          type: integer
+        heartbeat_slug:
+          type: string
+        host_id:
+          description: optional link to a monitored host
+          type: string
+        id:
+          type: string
+        incident_count_30d:
+          type: integer
+        incidents:
+          items:
+            $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.Incident'
+          type: array
+          uniqueItems: false
+        interval:
+          description: in seconds
+          type: integer
+        is_active:
+          type: boolean
+        keyword:
+          type: string
+        keyword_mode:
+          type: string
+        last_checked:
+          type: string
+        last_ping_at:
+          type: string
+        last_status_transition:
+          type: string
+        metadata:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto.ResourceMetaDataResponse'
+        metadata_pending:
+          type: boolean
+        name:
+          type: string
+        notification_channels:
+          items:
+            $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.NotificationChannel'
+          type: array
+          uniqueItems: false
+        protocol_port:
+          type: integer
+        protocol_type:
+          type: string
+        reminder_interval_minutes:
+          type: integer
+        response_time:
+          type: integer
+        response_times:
+          items:
+            $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto.ResponseTimePoint'
+          type: array
+          uniqueItems: false
+        status:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceStatus'
+        tags:
+          items:
+            $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.Tags'
+          type: array
+          uniqueItems: false
+        target:
+          type: string
+        timeout:
+          description: in seconds
+          type: integer
+        type:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceType'
+        updated_at:
+          type: string
+        uptime_7d:
+          type: number
+        uptime_30d:
+          type: number
+        waiting:
+          type: boolean
+      type: object
+    github_com_denisakp_ogoune_internal_dto.ResponseTimePoint:
+      properties:
+        response_time:
+          description: in milliseconds
+          type: integer
+        timestamp:
+          type: string
+      type: object
+    github_com_denisakp_ogoune_internal_dto.UpdateResourcePayload:
+      properties:
+        component_id:
+          type: string
+        confirmation_checks:
+          type: integer
+        confirmation_interval:
+          type: integer
+        expiry_alert_thresholds:
+          type: string
+        flap_detection_enabled:
+          type: boolean
+        flap_max_duration_minutes:
+          type: integer
+        flap_threshold:
+          type: integer
+        flap_window_seconds:
+          type: integer
+        heartbeat_grace:
+          type: integer
+        heartbeat_interval:
+          type: integer
+        interval:
+          type: integer
+        is_active:
+          type: boolean
+        keyword:
+          type: string
+        keyword_mode:
+          type: string
+        name:
+          type: string
+        protocol_port:
+          type: integer
+        protocol_type:
+          type: string
+        reminder_interval_minutes:
+          type: integer
+        tags:
+          description: Tag IDs (ULIDs) - must reference existing tags
+          items:
+            type: string
+          type: array
+          uniqueItems: false
+        target:
+          type: string
+        timeout:
+          type: integer
+        type:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_domain.ResourceType'
+      type: object
     github_com_denisakp_ogoune_internal_dto_v1.AddTagsRequest:
       properties:
         tag_ids:
@@ -885,32 +1149,6 @@ components:
         credential:
           type: string
         prefix:
-          type: string
-      type: object
-    github_com_denisakp_ogoune_internal_dto_v1.CreateMonitorRequest:
-      properties:
-        component_id:
-          type: string
-        interval:
-          type: integer
-        keyword:
-          type: string
-        name:
-          type: string
-        protocol_port:
-          type: integer
-        protocol_type:
-          type: string
-        tags:
-          items:
-            type: string
-          type: array
-          uniqueItems: false
-        target:
-          type: string
-        timeout:
-          type: integer
-        type:
           type: string
       type: object
     github_com_denisakp_ogoune_internal_dto_v1.CreateTagRequest:
@@ -1454,6 +1692,13 @@ components:
         meta:
           $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MetaResponse'
       type: object
+    github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse:
+      properties:
+        data:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto.ResourceResponse'
+        meta:
+          $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.MetaResponse'
+      type: object
     github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_AnnouncementResponse:
       properties:
         data:
@@ -1661,32 +1906,6 @@ components:
             $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.WidgetInstance'
           type: array
           uniqueItems: false
-      type: object
-    github_com_denisakp_ogoune_internal_dto_v1.UpdateMonitorRequest:
-      properties:
-        component_id:
-          type: string
-        interval:
-          type: integer
-        keyword:
-          type: string
-        name:
-          type: string
-        protocol_port:
-          type: integer
-        protocol_type:
-          type: string
-        tags:
-          items:
-            type: string
-          type: array
-          uniqueItems: false
-        target:
-          type: string
-        timeout:
-          type: integer
-        type:
-          type: string
       type: object
     github_com_denisakp_ogoune_internal_dto_v1.UpdateReportSettingsRequest:
       properties:
@@ -2682,7 +2901,7 @@ paths:
             schema:
               oneOf:
               - type: object
-              - $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.CreateMonitorRequest'
+              - $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto.CreateResourcePayload'
                 description: Monitor payload
                 summary: body
         description: Monitor payload
@@ -2692,7 +2911,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse'
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse'
           description: Created
         "403":
           content:
@@ -2748,12 +2967,17 @@ paths:
         required: true
         schema:
           type: string
+      - description: Number of recent response-time points to include (default 60)
+        in: query
+        name: limit
+        schema:
+          type: integer
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse'
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse'
           description: OK
         "404":
           content:
@@ -2780,7 +3004,7 @@ paths:
             schema:
               oneOf:
               - type: object
-              - $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.UpdateMonitorRequest'
+              - $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto.UpdateResourcePayload'
                 description: Partial update payload
                 summary: body
         description: Partial update payload
@@ -2790,7 +3014,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse'
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse'
           description: OK
         "403":
           content:
@@ -2829,7 +3053,7 @@ paths:
             schema:
               oneOf:
               - type: object
-              - $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.UpdateMonitorRequest'
+              - $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto.UpdateResourcePayload'
                 description: Update payload
                 summary: body
         description: Update payload
@@ -2839,7 +3063,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse'
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse'
           description: OK
         "403":
           content:
@@ -3125,7 +3349,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse'
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse'
           description: OK
         "403":
           content:
@@ -3158,7 +3382,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse'
+                $ref: '#/components/schemas/github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse'
           description: OK
         "403":
           content:

--- a/internal/api/handler/v1/bench_test.go
+++ b/internal/api/handler/v1/bench_test.go
@@ -52,6 +52,9 @@ func (s *benchMonitorService) ListAll(ctx context.Context) ([]*domain.Resource, 
 func (s *benchMonitorService) GetResourceByID(ctx context.Context, id string) (*domain.Resource, error) {
 	return s.repo.FindByID(ctx, id)
 }
+func (s *benchMonitorService) GetResourceByIDWithResponseTimes(_ context.Context, _ string, _ int) (*dto.ResourceResponse, error) {
+	panic("bench harness: GetResourceByIDWithResponseTimes not used")
+}
 func (s *benchMonitorService) CreateResource(_ context.Context, _ *dto.CreateResourcePayload) (*domain.Resource, error) {
 	panic("bench harness: CreateResource not used")
 }

--- a/internal/api/handler/v1/monitor_handler.go
+++ b/internal/api/handler/v1/monitor_handler.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -22,6 +24,7 @@ type MonitorV1ServiceInterface interface {
 	ListAll(ctx context.Context) ([]*domain.Resource, error)
 	ListByFilter(ctx context.Context, f dynquery.MonitorFilter, page, perPage int) ([]*domain.Resource, int, error)
 	GetResourceByID(ctx context.Context, id string) (*domain.Resource, error)
+	GetResourceByIDWithResponseTimes(ctx context.Context, id string, limit int) (*dto.ResourceResponse, error)
 	CreateResource(ctx context.Context, payload *dto.CreateResourcePayload) (*domain.Resource, error)
 	UpdateResource(ctx context.Context, id string, payload *dto.UpdateResourcePayload) (*domain.Resource, error)
 	DeleteResource(ctx context.Context, resourceID string) error
@@ -55,7 +58,9 @@ func NewMonitorHandler(svc MonitorV1ServiceInterface, live monitorLiveProvider, 
 	return &MonitorHandler{service: svc, live: live, uptime: uptime}
 }
 
-// mapMonitorResponse maps a domain.Resource to a v1 MonitorResponse.
+// mapMonitorResponse maps a domain.Resource to a thin v1 MonitorResponse. Still used
+// by the monitor↔host link/unlink endpoints (host_handler.go); the CRUD/list endpoints
+// now return the rich dto.ResourceResponse (spec 085 Phase 2a).
 func mapMonitorResponse(r *domain.Resource) dtoV1.MonitorResponse {
 	tags := make([]string, 0, len(r.Tags))
 	for _, t := range r.Tags {
@@ -120,9 +125,11 @@ func (h *MonitorHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := make([]dtoV1.MonitorResponse, 0, len(items))
+	data := make([]dto.ResourceResponse, 0, len(items))
 	for _, res := range items {
-		data = append(data, mapMonitorResponse(res))
+		if res != nil {
+			data = append(data, dto.ToResourceListResponse(*res))
+		}
 	}
 
 	respondPaginated(w, data, dtoV1.MetaResponse{
@@ -139,12 +146,19 @@ func (h *MonitorHandler) List(w http.ResponseWriter, r *http.Request) {
 // @Security    BearerAuth
 // @Produce     json
 // @Param       id path string true "Monitor ID"
-// @Success     200 {object} dtoV1.SingleResponse[dtoV1.MonitorResponse]
+// @Param       limit query int false "Number of recent response-time points to include (default 60)"
+// @Success     200 {object} dtoV1.SingleResponse[dto.ResourceResponse]
 // @Failure     404 {object} dtoV1.ErrorResponse
 // @Router      /monitors/{id} [get]
 func (h *MonitorHandler) Get(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	res, err := h.service.GetResourceByID(r.Context(), id)
+	limit := 60
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	res, err := h.service.GetResourceByIDWithResponseTimes(r.Context(), id, limit)
 	if err != nil {
 		if errors.Is(err, service.ErrResourceNotFound) {
 			respondError(w, r, http.StatusNotFound, "RESOURCE_NOT_FOUND", "monitor not found")
@@ -153,7 +167,7 @@ func (h *MonitorHandler) Get(w http.ResponseWriter, r *http.Request) {
 		respondError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to get monitor")
 		return
 	}
-	respond(w, http.StatusOK, mapMonitorResponse(res))
+	respond(w, http.StatusOK, res)
 }
 
 // Create handles POST /api/v1/monitors
@@ -163,53 +177,40 @@ func (h *MonitorHandler) Get(w http.ResponseWriter, r *http.Request) {
 // @Security    BearerAuth
 // @Accept      json
 // @Produce     json
-// @Param       body body dtoV1.CreateMonitorRequest true "Monitor payload"
-// @Success     201 {object} dtoV1.SingleResponse[dtoV1.MonitorResponse]
+// @Param       body body dto.CreateResourcePayload true "Monitor payload"
+// @Success     201 {object} dtoV1.SingleResponse[dto.ResourceResponse]
 // @Failure     422 {object} dtoV1.ErrorResponse
 // @Failure     403 {object} dtoV1.ErrorResponse
 // @Router      /monitors [post]
 func (h *MonitorHandler) Create(w http.ResponseWriter, r *http.Request) {
-	var req dtoV1.CreateMonitorRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	var payload dto.CreateResourcePayload
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 		respondError(w, r, http.StatusUnprocessableEntity, "VALIDATION_FAILED", "invalid request body")
 		return
 	}
 
 	var fieldErrs []dtoV1.FieldError
-	if strings.TrimSpace(req.Name) == "" {
+	if strings.TrimSpace(payload.Name) == "" {
 		fieldErrs = append(fieldErrs, dtoV1.FieldError{Field: "name", Message: "required"})
 	}
-	if strings.TrimSpace(req.Type) == "" {
+	if strings.TrimSpace(string(payload.Type)) == "" {
 		fieldErrs = append(fieldErrs, dtoV1.FieldError{Field: "type", Message: "required"})
 	}
-	if strings.TrimSpace(req.Target) == "" {
+	// target is required except for heartbeat monitors (parity with the root handler).
+	if strings.TrimSpace(payload.Target) == "" && payload.Type != domain.ResourceHeartbeat {
 		fieldErrs = append(fieldErrs, dtoV1.FieldError{Field: "target", Message: "required"})
 	}
-	if req.Interval <= 0 {
-		fieldErrs = append(fieldErrs, dtoV1.FieldError{Field: "interval", Message: "must be greater than 0"})
-	}
-	if req.Timeout <= 0 {
-		fieldErrs = append(fieldErrs, dtoV1.FieldError{Field: "timeout", Message: "must be greater than 0"})
+	if payload.ExpiryAlertThresholds != nil {
+		if err := validateExpiryThresholds(*payload.ExpiryAlertThresholds); err != nil {
+			fieldErrs = append(fieldErrs, dtoV1.FieldError{Field: "expiry_alert_thresholds", Message: err.Error()})
+		}
 	}
 	if len(fieldErrs) > 0 {
 		respondError(w, r, http.StatusUnprocessableEntity, "VALIDATION_FAILED", "validation failed", fieldErrs...)
 		return
 	}
 
-	payload := &dto.CreateResourcePayload{
-		Name:         req.Name,
-		Type:         domain.ResourceType(req.Type),
-		Target:       req.Target,
-		Interval:     req.Interval,
-		Timeout:      req.Timeout,
-		Tags:         req.Tags,
-		ComponentID:  req.ComponentID,
-		Keyword:      req.Keyword,
-		ProtocolType: req.ProtocolType,
-		ProtocolPort: req.ProtocolPort,
-	}
-
-	created, err := h.service.CreateResource(r.Context(), payload)
+	created, err := h.service.CreateResource(r.Context(), &payload)
 	if err != nil {
 		if errors.Is(err, service.ErrValidationFailed) {
 			respondError(w, r, http.StatusUnprocessableEntity, "VALIDATION_FAILED", err.Error())
@@ -218,7 +219,7 @@ func (h *MonitorHandler) Create(w http.ResponseWriter, r *http.Request) {
 		respondError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to create monitor")
 		return
 	}
-	respond(w, http.StatusCreated, mapMonitorResponse(created))
+	respond(w, http.StatusCreated, dto.ToResourceDetailResponse(*created))
 }
 
 // Update handles PUT /api/v1/monitors/{id} (full-shape update; partial semantics).
@@ -229,8 +230,8 @@ func (h *MonitorHandler) Create(w http.ResponseWriter, r *http.Request) {
 // @Accept      json
 // @Produce     json
 // @Param       id   path string true "Monitor ID"
-// @Param       body body dtoV1.UpdateMonitorRequest true "Update payload"
-// @Success     200 {object} dtoV1.SingleResponse[dtoV1.MonitorResponse]
+// @Param       body body dto.UpdateResourcePayload true "Update payload"
+// @Success     200 {object} dtoV1.SingleResponse[dto.ResourceResponse]
 // @Failure     404 {object} dtoV1.ErrorResponse
 // @Failure     403 {object} dtoV1.ErrorResponse
 // @Router      /monitors/{id} [put]
@@ -245,43 +246,32 @@ func (h *MonitorHandler) Update(w http.ResponseWriter, r *http.Request) { h.appl
 // @Accept      json
 // @Produce     json
 // @Param       id   path string true "Monitor ID"
-// @Param       body body dtoV1.UpdateMonitorRequest true "Partial update payload"
-// @Success     200 {object} dtoV1.SingleResponse[dtoV1.MonitorResponse]
+// @Param       body body dto.UpdateResourcePayload true "Partial update payload"
+// @Success     200 {object} dtoV1.SingleResponse[dto.ResourceResponse]
 // @Failure     404 {object} dtoV1.ErrorResponse
 // @Failure     403 {object} dtoV1.ErrorResponse
 // @Failure     422 {object} dtoV1.ErrorResponse
 // @Router      /monitors/{id} [patch]
 func (h *MonitorHandler) Patch(w http.ResponseWriter, r *http.Request) { h.applyUpdate(w, r) }
 
-// applyUpdate decodes the pointer-shaped UpdateMonitorRequest and applies it as a
-// partial update (shared by PUT + PATCH).
+// applyUpdate decodes the full pointer-shaped UpdateResourcePayload and applies it as
+// a partial update (shared by PUT + PATCH). Only supplied fields change.
 func (h *MonitorHandler) applyUpdate(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
-	var req dtoV1.UpdateMonitorRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	var payload dto.UpdateResourcePayload
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 		respondError(w, r, http.StatusUnprocessableEntity, "VALIDATION_FAILED", "invalid request body")
 		return
 	}
-
-	payload := &dto.UpdateResourcePayload{
-		Name:         req.Name,
-		Target:       req.Target,
-		Interval:     req.Interval,
-		Timeout:      req.Timeout,
-		ComponentID:  req.ComponentID,
-		Keyword:      req.Keyword,
-		ProtocolType: req.ProtocolType,
-		ProtocolPort: req.ProtocolPort,
-	}
-	if req.Type != nil {
-		t := domain.ResourceType(*req.Type)
-		payload.Type = &t
-	}
-	if req.Tags != nil {
-		payload.Tags = &req.Tags
+	if payload.ExpiryAlertThresholds != nil {
+		if err := validateExpiryThresholds(*payload.ExpiryAlertThresholds); err != nil {
+			respondError(w, r, http.StatusUnprocessableEntity, "VALIDATION_FAILED", "validation failed",
+				dtoV1.FieldError{Field: "expiry_alert_thresholds", Message: err.Error()})
+			return
+		}
 	}
 
-	updated, err := h.service.UpdateResource(r.Context(), id, payload)
+	updated, err := h.service.UpdateResource(r.Context(), id, &payload)
 	if err != nil {
 		if errors.Is(err, service.ErrResourceNotFound) {
 			respondError(w, r, http.StatusNotFound, "RESOURCE_NOT_FOUND", "monitor not found")
@@ -294,7 +284,28 @@ func (h *MonitorHandler) applyUpdate(w http.ResponseWriter, r *http.Request) {
 		respondError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to update monitor")
 		return
 	}
-	respond(w, http.StatusOK, mapMonitorResponse(updated))
+	respond(w, http.StatusOK, dto.ToResourceDetailResponse(*updated))
+}
+
+// validateExpiryThresholds mirrors the root handler's check: CSV of integers 1–365.
+func validateExpiryThresholds(s string) error {
+	if s == "" {
+		return nil
+	}
+	for _, p := range strings.Split(s, ",") {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		v, err := strconv.Atoi(p)
+		if err != nil {
+			return fmt.Errorf("invalid threshold value %q: must be an integer", p)
+		}
+		if v <= 0 || v > 365 {
+			return fmt.Errorf("threshold value %d is out of range (must be 1–365)", v)
+		}
+	}
+	return nil
 }
 
 // GetLive handles GET /api/v1/monitors/{id}/live — live snapshot (spec 085 parity).
@@ -436,7 +447,7 @@ func (h *MonitorHandler) Delete(w http.ResponseWriter, r *http.Request) {
 // @Tags        monitors
 // @Security    BearerAuth
 // @Param       id path string true "Monitor ID"
-// @Success     200 {object} dtoV1.SingleResponse[dtoV1.MonitorResponse]
+// @Success     200 {object} dtoV1.SingleResponse[dto.ResourceResponse]
 // @Failure     404 {object} dtoV1.ErrorResponse
 // @Failure     403 {object} dtoV1.ErrorResponse
 // @Router      /monitors/{id}/pause [post]
@@ -455,7 +466,7 @@ func (h *MonitorHandler) Pause(w http.ResponseWriter, r *http.Request) {
 		respondError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to get updated monitor")
 		return
 	}
-	respond(w, http.StatusOK, mapMonitorResponse(res))
+	respond(w, http.StatusOK, dto.ToResourceDetailResponse(*res))
 }
 
 // Resume handles POST /api/v1/monitors/{id}/resume
@@ -464,7 +475,7 @@ func (h *MonitorHandler) Pause(w http.ResponseWriter, r *http.Request) {
 // @Tags        monitors
 // @Security    BearerAuth
 // @Param       id path string true "Monitor ID"
-// @Success     200 {object} dtoV1.SingleResponse[dtoV1.MonitorResponse]
+// @Success     200 {object} dtoV1.SingleResponse[dto.ResourceResponse]
 // @Failure     404 {object} dtoV1.ErrorResponse
 // @Failure     403 {object} dtoV1.ErrorResponse
 // @Router      /monitors/{id}/resume [post]
@@ -483,5 +494,5 @@ func (h *MonitorHandler) Resume(w http.ResponseWriter, r *http.Request) {
 		respondError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to get updated monitor")
 		return
 	}
-	respond(w, http.StatusOK, mapMonitorResponse(res))
+	respond(w, http.StatusOK, dto.ToResourceDetailResponse(*res))
 }

--- a/internal/api/handler/v1/monitor_handler_test.go
+++ b/internal/api/handler/v1/monitor_handler_test.go
@@ -121,6 +121,18 @@ func (m *mockMonitorService) UpdateResource(_ context.Context, id string, payloa
 	return &domain.Resource{Base: domain.Base{ID: id, CreatedAt: time.Now(), UpdatedAt: time.Now()}}, nil
 }
 
+func (m *mockMonitorService) GetResourceByIDWithResponseTimes(_ context.Context, id string, _ int) (*dto.ResourceResponse, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	r := domain.Resource{}
+	r.ID = id
+	if m.resource != nil {
+		r = *m.resource
+	}
+	return &dto.ResourceResponse{Resource: r}, nil
+}
+
 func (m *mockMonitorService) AddTagsToResource(_ context.Context, _ string, tagIDs []string) error {
 	m.lastTagIDs = tagIDs
 	return m.addTagsErr
@@ -397,6 +409,10 @@ type mockMonitorServiceNotFound struct {
 }
 
 func (m *mockMonitorServiceNotFound) GetResourceByID(_ context.Context, _ string) (*domain.Resource, error) {
+	return nil, errNotFound
+}
+
+func (m *mockMonitorServiceNotFound) GetResourceByIDWithResponseTimes(_ context.Context, _ string, _ int) (*dto.ResourceResponse, error) {
 	return nil, errNotFound
 }
 

--- a/internal/api/handler/v1/monitor_parity_test.go
+++ b/internal/api/handler/v1/monitor_parity_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	v1 "github.com/denisakp/ogoune/internal/api/handler/v1"
+	"github.com/denisakp/ogoune/internal/domain"
 	"github.com/denisakp/ogoune/internal/dto"
 	dtoV1 "github.com/denisakp/ogoune/internal/dto/v1"
 	"github.com/denisakp/ogoune/internal/service"
@@ -16,6 +17,38 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestMonitorParity_ListReturnsRichShape locks the spec-085 Phase-2a enrichment:
+// GET /api/v1/monitors now returns the rich dto.ResourceResponse (uptime_7d,
+// incident_count_30d, tags-as-objects) instead of the thin MonitorResponse.
+func TestMonitorParity_ListReturnsRichShape(t *testing.T) {
+	up := 99.5
+	inc := 3
+	res := &domain.Resource{
+		Name: "api", Type: domain.ResourceHTTP, Target: "https://x",
+		Uptime7d: &up, IncidentCount30d: &inc,
+		Tags: []*domain.Tags{{Base: domain.Base{ID: "tag1"}, Name: "prod"}},
+	}
+	res.ID = "m1"
+	router := newMonitorRouter(&mockMonitorService{resources: []*domain.Resource{res}})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/monitors?per_page=50", nil)
+	rr := httptest.NewRecorder()
+	router.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var body struct {
+		Data []map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	require.Len(t, body.Data, 1)
+	row := body.Data[0]
+	assert.Equal(t, 99.5, row["uptime_7d"], "rich field uptime_7d present")
+	assert.EqualValues(t, 3, row["incident_count_30d"], "rich field incident_count_30d present")
+	tags, ok := row["tags"].([]any)
+	require.True(t, ok && len(tags) == 1, "tags is an array of objects")
+	assert.Equal(t, "tag1", tags[0].(map[string]any)["id"], "tag object carries id (not just name)")
+}
 
 type liveStub struct {
 	resp *dto.LiveSnapshotResponse

--- a/web/packages/api-types/generated/schema.d.ts
+++ b/web/packages/api-types/generated/schema.d.ts
@@ -1371,7 +1371,7 @@ export interface paths {
             /** @description Monitor payload */
             requestBody: {
                 content: {
-                    "application/json": Record<string, never> | components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.CreateMonitorRequest"];
+                    "application/json": Record<string, never> | components["schemas"]["github_com_denisakp_ogoune_internal_dto.CreateResourcePayload"];
                 };
             };
             responses: {
@@ -1381,7 +1381,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse"];
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse"];
                     };
                 };
                 /** @description Forbidden */
@@ -1420,7 +1420,10 @@ export interface paths {
         /** Get a monitor by ID */
         get: {
             parameters: {
-                query?: never;
+                query?: {
+                    /** @description Number of recent response-time points to include (default 60) */
+                    limit?: number;
+                };
                 header?: never;
                 path: {
                     /** @description Monitor ID */
@@ -1436,7 +1439,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse"];
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse"];
                     };
                 };
                 /** @description Not Found */
@@ -1464,7 +1467,7 @@ export interface paths {
             /** @description Update payload */
             requestBody: {
                 content: {
-                    "application/json": Record<string, never> | components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.UpdateMonitorRequest"];
+                    "application/json": Record<string, never> | components["schemas"]["github_com_denisakp_ogoune_internal_dto.UpdateResourcePayload"];
                 };
             };
             responses: {
@@ -1474,7 +1477,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse"];
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse"];
                     };
                 };
                 /** @description Forbidden */
@@ -1554,7 +1557,7 @@ export interface paths {
             /** @description Partial update payload */
             requestBody: {
                 content: {
-                    "application/json": Record<string, never> | components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.UpdateMonitorRequest"];
+                    "application/json": Record<string, never> | components["schemas"]["github_com_denisakp_ogoune_internal_dto.UpdateResourcePayload"];
                 };
             };
             responses: {
@@ -1564,7 +1567,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse"];
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse"];
                     };
                 };
                 /** @description Forbidden */
@@ -1988,7 +1991,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse"];
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse"];
                     };
                 };
                 /** @description Forbidden */
@@ -2045,7 +2048,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_MonitorResponse"];
+                        "application/json": components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse"];
                     };
                 };
                 /** @description Forbidden */
@@ -3803,6 +3806,8 @@ export interface components {
         };
         /** @enum {string} */
         "github_com_denisakp_ogoune_internal_domain.ComponentStatus": "up" | "degraded" | "down";
+        /** @enum {string} */
+        "github_com_denisakp_ogoune_internal_domain.ExpiryStatus": "ok" | "warning" | "critical" | "expired";
         "github_com_denisakp_ogoune_internal_domain.Incident": {
             cause?: string;
             created_at?: string;
@@ -3986,6 +3991,36 @@ export interface components {
             resources?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.Resource"][];
             updated_at?: string;
         };
+        "github_com_denisakp_ogoune_internal_dto.CreateResourcePayload": {
+            component_id?: string;
+            confirmation_checks?: number;
+            confirmation_interval?: number;
+            expiry_alert_thresholds?: string;
+            flap_detection_enabled?: boolean;
+            flap_max_duration_minutes?: number;
+            flap_threshold?: number;
+            flap_window_seconds?: number;
+            heartbeat_grace?: number;
+            heartbeat_interval?: number;
+            interval: number;
+            keyword?: string;
+            keyword_mode?: string;
+            name: string;
+            /**
+             * @description NotificationChannelNames are channel names to attach; resolved to IDs at create time.
+             *     Channels must already exist (they hold secrets and are never created here). Used by the
+             *     bulk import path; missing name is a validation error.
+             */
+            notification_channel_names?: string[];
+            protocol_port?: number;
+            protocol_type?: string;
+            reminder_interval_minutes?: number;
+            /** @description Tag names - will be created if they don't exist */
+            tags?: string[];
+            target: string;
+            timeout: number;
+            type: components["schemas"]["github_com_denisakp_ogoune_internal_domain.ResourceType"];
+        };
         "github_com_denisakp_ogoune_internal_dto.LiveActiveIncident": {
             cause?: string;
             id?: string;
@@ -4132,6 +4167,95 @@ export interface components {
             incidents?: number;
             uptime_ratio?: number;
         };
+        "github_com_denisakp_ogoune_internal_dto.ResourceMetaDataResponse": {
+            domain_days_remaining?: number;
+            domain_expiration_date?: string;
+            domain_registrar?: string;
+            ssl_days_remaining?: number;
+            ssl_expiration_date?: string;
+            ssl_issuer?: string;
+        };
+        "github_com_denisakp_ogoune_internal_dto.ResourceResponse": {
+            component?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.Component"];
+            component_id?: string;
+            confirmation_checks?: number;
+            confirmation_interval?: number;
+            created_at?: string;
+            credential?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.ResourceCredential"];
+            expiry_alert_thresholds?: string;
+            expiry_status?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.ExpiryStatus"];
+            failure_count?: number;
+            flap_detection_enabled?: boolean;
+            flap_max_duration_minutes?: number;
+            flap_started_at?: string;
+            flap_threshold?: number;
+            flap_window_seconds?: number;
+            heartbeat_grace?: number;
+            heartbeat_interval?: number;
+            heartbeat_slug?: string;
+            /** @description optional link to a monitored host */
+            host_id?: string;
+            id?: string;
+            incident_count_30d?: number;
+            incidents?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.Incident"][];
+            /** @description in seconds */
+            interval?: number;
+            is_active?: boolean;
+            keyword?: string;
+            keyword_mode?: string;
+            last_checked?: string;
+            last_ping_at?: string;
+            last_status_transition?: string;
+            metadata?: components["schemas"]["github_com_denisakp_ogoune_internal_dto.ResourceMetaDataResponse"];
+            metadata_pending?: boolean;
+            name?: string;
+            notification_channels?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.NotificationChannel"][];
+            protocol_port?: number;
+            protocol_type?: string;
+            reminder_interval_minutes?: number;
+            response_time?: number;
+            response_times?: components["schemas"]["github_com_denisakp_ogoune_internal_dto.ResponseTimePoint"][];
+            status?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.ResourceStatus"];
+            tags?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.Tags"][];
+            target?: string;
+            /** @description in seconds */
+            timeout?: number;
+            type?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.ResourceType"];
+            updated_at?: string;
+            uptime_7d?: number;
+            uptime_30d?: number;
+            waiting?: boolean;
+        };
+        "github_com_denisakp_ogoune_internal_dto.ResponseTimePoint": {
+            /** @description in milliseconds */
+            response_time?: number;
+            timestamp?: string;
+        };
+        "github_com_denisakp_ogoune_internal_dto.UpdateResourcePayload": {
+            component_id?: string;
+            confirmation_checks?: number;
+            confirmation_interval?: number;
+            expiry_alert_thresholds?: string;
+            flap_detection_enabled?: boolean;
+            flap_max_duration_minutes?: number;
+            flap_threshold?: number;
+            flap_window_seconds?: number;
+            heartbeat_grace?: number;
+            heartbeat_interval?: number;
+            interval?: number;
+            is_active?: boolean;
+            keyword?: string;
+            keyword_mode?: string;
+            name?: string;
+            protocol_port?: number;
+            protocol_type?: string;
+            reminder_interval_minutes?: number;
+            /** @description Tag IDs (ULIDs) - must reference existing tags */
+            tags?: string[];
+            target?: string;
+            timeout?: number;
+            type?: components["schemas"]["github_com_denisakp_ogoune_internal_domain.ResourceType"];
+        };
         "github_com_denisakp_ogoune_internal_dto_v1.AddTagsRequest": {
             tag_ids?: string[];
         };
@@ -4188,18 +4312,6 @@ export interface components {
         "github_com_denisakp_ogoune_internal_dto_v1.CreateHostCredentialResponse": {
             credential?: string;
             prefix?: string;
-        };
-        "github_com_denisakp_ogoune_internal_dto_v1.CreateMonitorRequest": {
-            component_id?: string;
-            interval?: number;
-            keyword?: string;
-            name?: string;
-            protocol_port?: number;
-            protocol_type?: string;
-            tags?: string[];
-            target?: string;
-            timeout?: number;
-            type?: string;
         };
         "github_com_denisakp_ogoune_internal_dto_v1.CreateTagRequest": {
             color?: string;
@@ -4464,6 +4576,10 @@ export interface components {
             data?: components["schemas"]["github_com_denisakp_ogoune_internal_dto.LiveSnapshotResponse"];
             meta?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.MetaResponse"];
         };
+        "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_ResourceResponse": {
+            data?: components["schemas"]["github_com_denisakp_ogoune_internal_dto.ResourceResponse"];
+            meta?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.MetaResponse"];
+        };
         "github_com_denisakp_ogoune_internal_dto_v1.SingleResponse-github_com_denisakp_ogoune_internal_dto_v1_AnnouncementResponse": {
             data?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.AnnouncementResponse"];
             meta?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.MetaResponse"];
@@ -4577,18 +4693,6 @@ export interface components {
             scope?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.DashboardScope"];
             visibility?: string;
             widgets?: components["schemas"]["github_com_denisakp_ogoune_internal_dto_v1.WidgetInstance"][];
-        };
-        "github_com_denisakp_ogoune_internal_dto_v1.UpdateMonitorRequest": {
-            component_id?: string;
-            interval?: number;
-            keyword?: string;
-            name?: string;
-            protocol_port?: number;
-            protocol_type?: string;
-            tags?: string[];
-            target?: string;
-            timeout?: number;
-            type?: string;
         };
         "github_com_denisakp_ogoune_internal_dto_v1.UpdateReportSettingsRequest": {
             enabled?: boolean;


### PR DESCRIPTION
## Spec 085 Phase 2a — enrich v1 monitors to the rich resource shape

**Prerequisite for the frontend repoint + root deletion (2b).** The code map for Phase 2 disproved the PRD's "thin mapping layer" premise: v1 `MonitorResponse` is a strict subset of the root `ResourceResponse`, missing fields the UI reads (tags-as-objects, `last_checked`, `uptime_7d`, `incident_count_30d`, `response_times`, `expiry_status`, `waiting`, SSL/domain days-remaining, monitor-type fields). A thin mapper would regress list/detail/SSL/heartbeat views. So v1 converges onto the root's rich shape first.

### Changes
- **List** → `dto.ToResourceListResponse` (identical to the root list; `ListByFilter` already populates the enrichment aggregates via the same `attach*` helpers).
- **Get** → `GetResourceByIDWithResponseTimes` (full detail: response_times + expiry).
- **Create / Update / PATCH** → decode the full `dto.Create/UpdateResourcePayload` (no dropped fields), return `dto.ToResourceDetailResponse`; ported the expiry-threshold validation + heartbeat-target exemption; service validation → 422.
- **Pause / Resume** → re-fetch + rich response.
- Widened `MonitorV1ServiceInterface` with `GetResourceByIDWithResponseTimes`. The thin `MonitorResponse`/`mapMonitorResponse` are kept only for the monitor↔host link endpoints.

### Notes
- **v1 monitor contract change** (thin → rich) — safe: beta, and the SPA is the only v1 consumer (repointed via a ~identity mapper in 2b). Reads open, writes read/write-scoped. OpenAPI + fe-types regenerated.
- **For 2b:** v1 list is paginated (max 100) while the SPA's `fetchResources` expects the full set — 2b must add an all/large mode or paginate.

### Tests
- New rich-shape list assertion (`uptime_7d` / `incident_count_30d` / tags-as-objects present).
- All 190 existing v1 handler tests green (rich shape is backward-safe). `go test -race` + `make ci-local` green.

> **2b (next, gated on this):** repoint `web/src/services/resourceService.ts` to `v1/monitors/*` via a near-identity mapper (unwrap `{data}`, handle list pagination), repoint the MSW specs, then delete `resource_handler.go` + the `/resources` route block + trim `NewRouter`. Ships frontend + backend together (hard-switch).