### PR TITLE
chore(release): v1.0.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.0.0-beta.2] - 2026-08-03
+
 ### Changed
 
 - **⌘K command palette now searches server-side (spec 084 frontend swap)** — the palette

--- a/release-notes/v1.0.0-beta.2.md
+++ b/release-notes/v1.0.0-beta.2.md
@@ -1,0 +1,42 @@
+# Ogoune v1.0.0-beta.2
+
+A backend/API-focused release: server-side search for the command palette, and
+the completion of the root→v1 API convergence — the versioned `/api/v1/*` API
+is now the single source of truth across every domain.
+
+## Highlights
+
+**Search**
+- `GET /api/v1/search` — server-side search across monitors, incidents, and
+  app pages, powering the ⌘K command palette beyond the client-side (in-memory)
+  window. The palette now queries this endpoint (debounced 150 ms) once a query
+  reaches 2 characters, with the local Fuse.js search kept as an offline/error
+  fallback.
+
+**Root → v1 API convergence**
+- `resources`, `tags`, `incidents`, `notification-channels`, and `components`
+  are fully migrated off the frozen non-versioned root API onto `/api/v1/*`.
+  The duplicated root handlers and routes are deleted — `/api/v1/*` is now the
+  single API surface for these domains.
+- Real bugs fixed along the way:
+  - A tag-by-id fetch that 404'd on every call.
+  - A "Resolve incident" button that called a route which never existed.
+  - Notification channel secrets (password / auth token / account SID) that
+    the old root API returned in cleartext — now masked, with edits preserving
+    the stored secret when left blank.
+  - The v1 components handler, which had bypassed `ComponentService` entirely
+    and lost derived status, resource-membership rules, and the delete guard —
+    rebuilt on the service.
+  - A stale incident route reference (`{name:'Incident'}`, which doesn't
+    exist) in the search-palette navigation, now using the contract's
+    `deep_link`.
+
+## Upgrade notes
+
+- No database migration in this release.
+- No breaking API changes — this is additive/internal convergence on an
+  already-beta API surface.
+
+## Full changelog
+
+See [CHANGELOG.md](../CHANGELOG.md) → `[1.0.0-beta.2]`.


### PR DESCRIPTION
Release changelog + release notes for v1.0.0-beta.2 (search endpoint spec 084 + root→v1 convergence specs 085-086, PRs #52-#60, already merged to main via #61).