### PR TITLE
docs(nebula): close feature/doc coverage gap, fix roadmap.md drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Public docs coverage for previously-undocumented shipped features (`nebula/`)** — new
+  narrative guide pages for status pages, dashboards, scheduled reports, tags & components,
+  maintenance windows, API keys & 2FA, bulk YAML import/export, and Prometheus observability
+  (`/metrics` + the Grafana dashboard / alert-rules endpoints). Every page is grounded directly
+  in the v1 API and Go source rather than roadmap prose. Closes most of the gap between what's
+  shipped and what's publicly documented.
+- **Mermaid diagrams in `nebula/`** — `vitepress-plugin-mermaid` wired into the VitePress build;
+  `guide/incidents.md` gets a state-diagram of the incident lifecycle.
+
+### Changed
+
+- **`guide/monitor-types.md` rewritten** — was a six-row stub table; now includes real config
+  examples per type, including the previously-undocumented Heartbeat/Push, SSL/domain expiry,
+  and Protocol-with-auth (Redis/MySQL/PostgreSQL) variants.
+- **`enterprise/index.md` corrected** — no longer misdescribes PostgreSQL + Redis as an EE
+  differentiator (it's Community Edition, see `self-host/production.md`); now lists the actual
+  EE scope (team management, SSO/SAML, multi-tenancy, SOC 2 audit logs, dedicated support) with
+  an honest note that most of it is still on the roadmap, not shipped.
+- **`roadmap.md` drift fixed** — scheduled reports and the host agent were marked `[ ]` Planned
+  despite already being shipped; dashboards, YAML bulk import/export, announcements, and the
+  search endpoint were shipped but missing from the document entirely. All corrected against
+  CHANGELOG/git history.
+
+### Fixed
+
+- **`nebula/` dev server startup** — `vitepress-plugin-mermaid`'s hardcoded `optimizeDeps.include`
+  list doesn't resolve under pnpm's strict linking (and lists `debug`, which current mermaid no
+  longer even depends on). Added `nebula/.npmrc` hoist pattern for the real transitive deps and
+  an explicit `debug` devDependency for the stale one.
+
 ## [1.0.0-beta.2] - 2026-08-03
 
 ### Changed

--- a/nebula/.npmrc
+++ b/nebula/.npmrc
@@ -1,0 +1,9 @@
+; vitepress-plugin-mermaid's Vite optimizeDeps.include lists mermaid's own
+; transitive deps by bare specifier, assuming a flat node_modules. pnpm's
+; strict linking doesn't hoist them by default, so the dev server 500s on
+; "Failed to resolve dependency" for these. Hoist just what mermaid needs.
+public-hoist-pattern[]=@braintree/sanitize-url
+public-hoist-pattern[]=dayjs
+public-hoist-pattern[]=debug
+public-hoist-pattern[]=cytoscape
+public-hoist-pattern[]=cytoscape-cose-bilkent

--- a/nebula/.vitepress/config.ts
+++ b/nebula/.vitepress/config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from 'vitepress'
+import { withMermaid } from 'vitepress-plugin-mermaid'
 
 // Ogoune public docs. Covers Community (CE) + Enterprise (EE) — same codebase,
 // EE features documented publicly (Portainer model). Cloud = the managed offering.
-export default defineConfig({
+export default withMermaid(defineConfig({
   title: 'Ogoune',
   description: 'Uptime monitoring that confirms before it cries wolf.',
   lang: 'en-US',
@@ -49,6 +50,28 @@ export default defineConfig({
             { text: 'Monitor types', link: '/guide/monitor-types' },
             { text: 'Incidents & confirmation', link: '/guide/incidents' },
             { text: 'Notifications', link: '/guide/notifications' },
+            { text: 'Maintenance windows', link: '/guide/maintenance-windows' },
+          ],
+        },
+        {
+          text: 'Organization',
+          items: [
+            { text: 'Tags & components', link: '/guide/tags-components' },
+          ],
+        },
+        {
+          text: 'Status pages & reporting',
+          items: [
+            { text: 'Public status pages', link: '/guide/status-pages' },
+            { text: 'Dashboards', link: '/guide/dashboards' },
+            { text: 'Scheduled reports', link: '/guide/reports' },
+          ],
+        },
+        {
+          text: 'Account & API',
+          items: [
+            { text: 'API keys & 2FA', link: '/guide/api-access' },
+            { text: 'Bulk import/export', link: '/guide/import-export' },
           ],
         },
       ],
@@ -61,6 +84,7 @@ export default defineConfig({
             { text: 'Production (Postgres + Redis)', link: '/self-host/production' },
             { text: 'Configuration', link: '/self-host/configuration' },
             { text: 'Host agent', link: '/self-host/agent' },
+            { text: 'Observability (Prometheus)', link: '/self-host/observability' },
           ],
         },
       ],
@@ -102,4 +126,4 @@ export default defineConfig({
       copyright: 'Copyright © Ogoune',
     },
   },
-})
+}))

--- a/nebula/enterprise/index.md
+++ b/nebula/enterprise/index.md
@@ -1,13 +1,33 @@
 # Enterprise Edition
 
-The Enterprise Edition (EE) targets production scale: **PostgreSQL** storage and an **Asynq/Redis** scheduler, enabling a stateless API tier with external workers.
+The Enterprise Edition (EE) is the commercial license for features that only make sense in a
+**multi-tenant, Cloud context** — not a "bigger database" tier.
 
-EE and Community share one codebase. EE features are documented publicly here — running them requires a valid license.
+::: tip Scaling Community Edition doesn't need EE
+PostgreSQL + Redis/Asynq are part of the free, Apache 2.0 Community Edition — see
+[Production self-hosting](/self-host/production). You don't need an EE license to run
+Ogoune at production scale on your own infrastructure.
+:::
 
-## What EE adds
+EE and Community share one codebase. EE features are documented publicly here — running them
+requires a valid license.
 
-- PostgreSQL-backed storage for larger fleets
-- Redis/Asynq distributed scheduling
-- Horizontal scaling (stateless API + external worker pool)
+## What EE licenses
 
-See [Licensing](/enterprise/licensing) for how the edition is detected and activated.
+- **Team management** — roles (Owner / Admin / Member / Viewer), invitation flow, permission matrix
+- **SSO / SAML** — Okta, Auth0, Azure AD, Google Workspace, generic SAML 2.0
+- **Multi-tenancy** — organization isolation, required for Cloud and shared deployments
+- **SOC 2 audit logs** — full action trail (user, action, resource, IP, outcome), filterable and exportable
+- **Certified compliance** — FIPS 140-2 / HIPAA-validated Vault-backed key management, advanced GDPR tooling
+- **Dedicated support** — SLA-backed response, security questionnaires, DPA
+
+::: warning Most of this is still being built
+As of this writing, the features above are on the
+[roadmap](https://github.com/denisakp/ogoune/blob/main/roadmap.md#h3--enterprise-edition-q4-2026--q1-2027)
+for Q4 2026 / Q1 2027. Today, `internal/ee/license/` only detects which edition is running
+(via the `ENTERPRISE_LICENSE_KEY` prefix) — it doesn't yet gate any behavior. We'd rather say
+that plainly than ship a page that overclaims.
+:::
+
+See [Licensing](/enterprise/licensing) for how edition detection works and how to obtain a
+commercial license.

--- a/nebula/guide/api-access.md
+++ b/nebula/guide/api-access.md
@@ -1,0 +1,68 @@
+# API access & account security
+
+Two things secure programmatic and human access to Ogoune: **API keys** for
+scripts and integrations, and **two-factor authentication (2FA)** for your own
+login. Both are managed from your account settings.
+
+## API keys
+
+An API key lets a script, CI job, or integration talk to the Ogoune API without
+a browser session. Create one under **Account → API keys**: give it a name, pick
+a scope, and optionally set an expiry date.
+
+Every key carries one of two **scopes**:
+
+- **`read`** — read-only. The key can `GET` monitors, incidents, hosts, and other
+  resources, but any write (create, update, delete) is rejected with `403`.
+- **`read_write`** — full read plus writes. Use this for automation that creates
+  monitors, acknowledges incidents, or mutates configuration.
+
+::: warning
+The full key is shown **once**, at creation time. Copy it immediately — Ogoune
+only ever stores a hash plus a short `pk_live_…` prefix, so it can never show you
+the secret again. Lost it? Revoke the key and create a new one.
+:::
+
+Keys are long-lived until you revoke them (**Account → API keys → Revoke**) or
+their optional expiry passes. Ogoune records each key's last-used time and IP so
+you can spot a stale or leaked credential.
+
+### Using a key
+
+Pass the key on every request, either in an `X-API-Key` header or as a bearer
+token — both are accepted:
+
+```bash
+# X-API-Key header
+curl https://your-ogoune/api/v1/monitors \
+  -H "X-API-Key: pk_live_xxxxxxxxxxxx"
+
+# ...or as a bearer token
+curl https://your-ogoune/api/v1/monitors \
+  -H "Authorization: Bearer pk_live_xxxxxxxxxxxx"
+```
+
+::: tip
+API keys can't manage other API keys — creating, listing, and revoking keys
+requires a logged-in session. This keeps a leaked key from minting more keys.
+:::
+
+## Two-factor authentication (2FA)
+
+2FA adds a time-based one-time password (TOTP) on top of your password. Enable it
+under **Account → Security → Enable 2FA**:
+
+1. Ogoune shows a QR code (an `otpauth://` URL). Scan it with an authenticator app
+   (Google Authenticator, 1Password, Authy, …).
+2. Enter the current 6-digit code to confirm. Ogoune then shows **10 one-time
+   backup codes** — store them somewhere safe.
+
+Once enabled, logging in becomes two steps: after your password, Ogoune returns a
+short-lived 2FA challenge and asks for the current authenticator code before
+issuing your session. Lost your device? Use one of the backup codes, or trigger
+an **email-based 2FA reset** from the login screen.
+
+::: warning
+Backup codes are shown once and each works only once. Disabling 2FA (**Account →
+Security → Disable 2FA**) also requires a valid code.
+:::

--- a/nebula/guide/dashboards.md
+++ b/nebula/guide/dashboards.md
@@ -1,0 +1,92 @@
+# Dashboards
+
+A **dashboard** is a saved custom view: pick which monitors it covers (its
+*scope*), drop in a few widgets, choose a time range and refresh interval, and
+Ogoune remembers it. Dashboards are config-only — Ogoune stores the layout and
+scope; the live metric data is rendered when you open the view.
+
+Anyone signed in can read every dashboard (reads are instance-wide), but only the
+**owner** (the user who created it) can edit or delete one.
+
+## Scope: which monitors a dashboard shows
+
+Every dashboard has a `scope` with a `mode` and a matching `payload`. The mode
+decides which field of the payload is used:
+
+| Mode | Payload field | Selects monitors by… |
+|---|---|---|
+| `tag` | `tagIds` | one or more tags |
+| `component` | `componentIds` | membership in a status-page component |
+| `type` | `types` | monitor type (e.g. `http`, `tcp`, `dns`) |
+| `manual` | `resourceIds` | an explicit hand-picked monitor list |
+
+::: tip
+`tag`, `component`, and `type` scopes are *dynamic* — a monitor that later gains
+the tag (or type) shows up automatically. `manual` is a fixed list you curate by
+ID.
+:::
+
+## Widgets
+
+Each dashboard holds an ordered list of widgets. A widget's `widgetTypeId` must be
+one of:
+
+- `uptime-stat` — uptime percentage tile
+- `incidents-list` — recent incidents
+- `response-time` — response-time chart
+- `resource-status-grid` — up/down grid across the scoped monitors
+
+`position` (an integer ≥ 0) sets the order; `title` and `config` are optional
+per-widget overrides.
+
+## Create a dashboard
+
+`POST /api/v1/dashboards` with a Bearer token. Here a dashboard scoped to two
+tags:
+
+```bash
+curl -X POST https://your-ogoune/api/v1/dashboards \
+  -H "Authorization: Bearer <api-key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Production",
+    "scope": { "mode": "tag", "payload": { "tagIds": ["tag_01H…", "tag_02H…"] } },
+    "widgets": [
+      { "id": "w1", "widgetTypeId": "uptime-stat", "position": 0 },
+      { "id": "w2", "widgetTypeId": "incidents-list", "position": 1 }
+    ],
+    "defaultTimeRange": "24h",
+    "refreshInterval": "1m",
+    "visibility": "team"
+  }'
+```
+
+To scope by **component** instead, swap the scope block for
+`{"mode":"component","payload":{"componentIds":["cmp_…"]}}`; for a **manual** list,
+`{"mode":"manual","payload":{"resourceIds":["mon_…","mon_…"]}}`. Only the payload
+field that matches the mode is read.
+
+Allowed enum values (validated server-side; a bad value returns `422`):
+
+- `defaultTimeRange`: `24h`, `7d`, `30d`, `90d`
+- `refreshInterval`: `off`, `30s`, `1m`, `5m`
+- `visibility`: `private`, `team`, `public`
+
+## Update, reorder, delete
+
+- `PATCH /api/v1/dashboards/{id}` — partial update; send only the fields you want
+  to change.
+- `PUT /api/v1/dashboards/{id}/layout` — replace the whole ordered widget list
+  (used when you drag widgets around):
+
+  ```json
+  { "widgets": [ { "id": "w2", "widgetTypeId": "incidents-list", "position": 0 },
+                 { "id": "w1", "widgetTypeId": "uptime-stat", "position": 1 } ] }
+  ```
+
+- `DELETE /api/v1/dashboards/{id}` — removes it.
+
+::: warning
+Edit, layout, and delete are **owner-only**. Calling them on someone else's
+dashboard returns `403 FORBIDDEN`.
+:::

--- a/nebula/guide/import-export.md
+++ b/nebula/guide/import-export.md
@@ -1,0 +1,63 @@
+# Bulk import & export
+
+Manage your monitors as code. Ogoune can **export** every monitor to a single
+YAML file and **import** a YAML manifest to create many monitors at once — handy
+for backups, migrating between instances, or version-controlling your setup.
+
+Both operations require a **read-write API key** (a read-only key gets `403`).
+
+## Export
+
+`GET /api/v1/monitors/export` returns a YAML manifest of **all** monitors in the
+instance (there is no filtering — it is a full dump). The response downloads as
+`ogoune-monitors.yaml`. Only declaration fields are emitted; IDs, timestamps,
+status, and metrics are omitted, so the file round-trips cleanly back through
+import.
+
+## Import
+
+`POST /api/v1/monitors/import` accepts a YAML manifest, either as the raw request
+body (`Content-Type: text/yaml`) or as a multipart file field named `manifest`.
+
+A manifest is a `version` (must be `1`), optional `defaults`, and a list of
+`resources`:
+
+```yaml
+version: 1
+defaults:
+  interval: 60        # applied to any monitor that omits the field
+  timeout: 10
+resources:
+  - name: Marketing site
+    type: http
+    target: https://example.com
+    tags: [public, web]
+    component: Website
+    notification_channels: [Ops email]
+  - name: Nightly backup job
+    type: heartbeat
+    heartbeat_interval: 3600
+    heartbeat_grace: 300
+```
+
+Every row needs a `name` and `type` (`http`, `tcp`, `dns`, `icmp`, `keyword`,
+`protocol`, or `heartbeat`). All types except `heartbeat` require a `target`.
+Type-specific fields: `keyword` needs `keyword`; `protocol` needs `protocol_type`
+and `protocol_port`; `heartbeat` needs `heartbeat_interval` and
+`heartbeat_grace`. `tags` and `component` are created automatically if they don't
+exist, but **notification channels must already exist** — a reference to an
+unknown channel fails the row.
+
+::: warning Create-only, all-or-nothing
+Import **only creates** monitors — it never updates an existing one. A monitor
+whose `name` already exists is **skipped** by default; pass
+`?duplicatePolicy=error` to fail instead. Otherwise, if **any** row is invalid,
+the **whole batch is rejected and nothing is written** — the response is a `422`
+carrying a per-row report (`index`, `valid`, `action`, `errors`) so you can fix
+and retry.
+:::
+
+::: tip Validate first
+Add `?dryRun=true` to validate a manifest and get the full row-by-row report
+without writing anything. A manifest is capped at 500 monitors.
+:::

--- a/nebula/guide/incidents.md
+++ b/nebula/guide/incidents.md
@@ -19,3 +19,20 @@ Related failures are grouped so a single upstream outage doesn't produce dozens 
 ## Lifecycle steps
 
 `detected` · `resource_down_alert` · `resolved` · `resource_up_alert` — steps may not all be present for every incident.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Monitoring
+    Monitoring --> Confirming: check fails
+    Confirming --> Monitoring: check recovers before N failures
+    Confirming --> detected: N consecutive failures
+    detected --> resource_down_alert: notification dispatched
+    resource_down_alert --> resolved: check recovers
+    resolved --> resource_up_alert: notification dispatched
+    resource_up_alert --> [*]
+```
+
+::: tip
+Not every incident carries all four steps — e.g. a resolved incident with no configured
+notification channel skips the alert steps but still records `detected` and `resolved`.
+:::

--- a/nebula/guide/maintenance-windows.md
+++ b/nebula/guide/maintenance-windows.md
@@ -1,0 +1,58 @@
+# Maintenance windows
+
+A **maintenance window** tells Ogoune that planned downtime is expected, so it
+doesn't page you for it. While a monitor is inside an active window, Ogoune still
+runs its checks and records the results — but it **suppresses false positives**:
+it won't advance failure counts, won't flip the monitor to `down`, and won't open
+incidents or fire notifications. The check results are simply tagged as
+maintenance activity.
+
+## Why use them
+
+Deploys, database migrations, and host reboots make healthy services look down.
+Without a window, a five-minute restart can trigger an incident and wake up
+whoever is on call. A maintenance window keeps that noise out of your incident
+history.
+
+## Scheduling a window
+
+Every window has a `strategy`, a `title`, and the `resource_ids` it applies to.
+There are two strategies:
+
+- **One-time** (`one_time`) — a single fixed window. Provide `start_at` and
+  `end_at` as RFC 3339 timestamps.
+- **Recurring** (`cron`) — a repeating window. Provide a `cron_expr`, a
+  `window_minutes` duration (how long each occurrence lasts), and optionally a
+  `timezone`. You can bound the recurrence with `effective_from` /
+  `effective_until`.
+
+Create one via the API (a read-write API key is required for writes):
+
+```bash
+# One-time window during a planned deploy
+curl -X POST https://your-ogoune/api/maintenances \
+  -H "Authorization: Bearer $OGOUNE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "title": "Nightly deploy",
+    "strategy": "one_time",
+    "start_at": "2026-08-04T02:00:00Z",
+    "end_at":   "2026-08-04T02:30:00Z",
+    "resource_ids": ["01J...","01K..."]
+  }'
+```
+
+For a recurring window, swap in `"strategy": "cron"`, e.g.
+`"cron_expr": "0 2 * * 0"` with `"window_minutes": 60` for a Sunday 02:00
+one-hour slot.
+
+::: tip
+A window's `status` moves through `scheduled → active → finished`. Need to end an
+active window early? Call `POST /api/maintenances/{id}/finish`.
+:::
+
+::: warning
+Starting a window does **not** resolve incidents that are already open — Ogoune
+only stops *creating* and advancing incidents while the window is active. Close
+any in-progress incident yourself, or schedule the window before the work begins.
+:::

--- a/nebula/guide/monitor-types.md
+++ b/nebula/guide/monitor-types.md
@@ -1,14 +1,91 @@
 # Monitor types
 
-Ogoune ships several check strategies.
+Ogoune ships several check strategies. Each implements a common `CheckStrategy`
+contract, so new types can be added without touching the scheduler or worker pool.
 
-| Type | Checks |
-|---|---|
-| **HTTP** | Status code, response time, redirects |
-| **TCP** | Port reachability |
-| **DNS** | Record resolution |
-| **ICMP** | Ping / host reachability |
-| **Keyword** | Presence/absence of a string in the response body |
-| **Protocol** | Protocol-specific handshakes |
+| Type | Checks | Key fields |
+|---|---|---|
+| **HTTP** | Status code (a `HEAD` in the 200–399 range is UP), response time, redirects | `target` (full URL) |
+| **TCP** | Port reachability | `target` (`host:port`) |
+| **DNS** | Record resolution (`LookupHost`) | `target` (hostname) |
+| **ICMP** | Ping / host reachability (single echo probe) | `target` (host) |
+| **Keyword** | Presence/absence of a string in the response body | `keyword`, `keyword_mode` |
+| **Heartbeat** | Push-based — you ping Ogoune on a schedule | `heartbeat_interval`, `heartbeat_grace` |
+| **Protocol** | Application-layer handshakes (Redis, MongoDB, FTP, SSH, MySQL, PostgreSQL, RabbitMQ, Kafka) | `protocol_type`, `protocol_port` |
 
-Each strategy implements a common `CheckStrategy` contract, so new types can be added without touching the scheduler or worker pool.
+Every monitor also takes the common fields `name`, `type`, `interval` (10–3600 s),
+`timeout` (1–60 s), and optional `confirmation_checks` / `confirmation_interval`
+(how many consecutive failures confirm an incident before alerting).
+
+## Keyword
+
+A `GET` request reads up to 512 KB of the body, then applies a **case-sensitive**
+substring match. `keyword_mode` is `contains` (UP when found) or `not_contains`
+(UP when absent).
+
+```json
+{ "type": "keyword", "target": "https://example.com/health",
+  "keyword": "OK", "keyword_mode": "contains" }
+```
+
+## Heartbeat (push)
+
+Instead of Ogoune reaching out, a heartbeat monitor waits for **your** job (cron,
+backup, worker) to check in. Ogoune generates a `heartbeat_slug`; ping it from your
+job:
+
+```
+POST /api/v1/heartbeat/ping/{slug}
+```
+
+The endpoint is public — no auth header — so a `curl` at the end of a script is
+enough. Configure `heartbeat_interval` (expected seconds between pings) and
+`heartbeat_grace` (extra slack before it's marked down).
+
+::: tip
+A brand-new heartbeat stays in a *waiting* state until its first ping arrives, so
+it never alerts before your job has run once.
+:::
+
+## SSL & domain expiry
+
+SSL certificate and domain (WHOIS) expiry are **not** a separate monitor type —
+they're enrichment on your active **HTTP** monitors. A daily job populates each
+resource's SSL issuer / expiry date and domain registrar / expiry date, then
+alerts as the deadline approaches.
+
+Thresholds are set per monitor via `expiry_alert_thresholds` (a comma-separated
+list of days-remaining, each 1–365). The default is `30,14,7,1`:
+
+```json
+{ "type": "http", "target": "https://example.com",
+  "expiry_alert_thresholds": "30,14,7,1" }
+```
+
+Status is derived from days remaining: **expired** (≤ 0), **critical** (≤ 7),
+**warning** (≤ 30), otherwise **ok**.
+
+## Protocol with authentication
+
+A protocol monitor picks its handler from `protocol_type` and connects on
+`protocol_port` (or the default: Redis 6379, MongoDB 27017, FTP 21, SSH 22,
+MySQL 3306, PostgreSQL 5432, RabbitMQ 5672, Kafka 9092). TLS is inferred from the
+target — `rediss://`, `?tls=true`, or `?sslmode=require`.
+
+For Redis, MySQL, and PostgreSQL you can go beyond port reachability and verify a
+real login. Create the monitor, then attach a credential:
+
+```
+POST /api/v1/resources/{id}/credentials
+{ "username": "monitor", "password": "s3cret" }
+```
+
+Redis uses `AUTH` (the ACL `AUTH <user> <pass>` form when a username is set);
+MySQL and PostgreSQL open an authenticated connection and ping it. An auth failure
+is reported distinctly from an unreachable port.
+
+::: warning
+Credentials are encrypted at rest (AES-256-GCM) and the password is never returned
+by the API — reads show a mask. Without a credential, MySQL/PostgreSQL monitors
+fall back to a plain TCP reachability check.
+:::

--- a/nebula/guide/notifications.md
+++ b/nebula/guide/notifications.md
@@ -17,4 +17,4 @@ Channel credentials are encrypted at rest with **AES-256-GCM**. They are never s
 
 ## Monthly reports
 
-Ogoune can deliver a monthly uptime report via the configured SMTP channel — generated for the previous completed month, idempotent per period.
+Ogoune can also email a monthly uptime recap — see [Scheduled reports](/guide/reports).

--- a/nebula/guide/reports.md
+++ b/nebula/guide/reports.md
@@ -1,0 +1,53 @@
+# Monthly reports
+
+Ogoune can email a **monthly uptime report** summarising the previous calendar
+month across all your monitors. It's an at-a-glance recap for stakeholders who
+don't live in the dashboard — one message, first of the month, no dashboard
+login required.
+
+## What's in the report
+
+Each report covers one completed month and contains:
+
+- **Overall uptime** percentage across all resources
+- **Incident count** for the period
+- **Total downtime** (in seconds)
+- A **per-resource breakdown** — name, uptime %, and incident count for each monitor
+
+Scope is currently **all resources** — the report always covers your whole fleet.
+
+## How it works
+
+The schedule is **fixed**: the report is generated for the *previous completed
+month* and there is no cron expression to configure. A background job runs once at
+startup and then daily; on each tick it checks whether the previous month already
+has a report and, if not, generates and sends it. This means a missed run (e.g.
+the instance was down on the 1st) **self-heals** on the next start or daily tick.
+Generation is **idempotent per period** — a given month is only ever sent once.
+
+Delivery goes through your **oldest configured SMTP notification channel**, sent to
+the recipient address you set. So you must have at least one
+[SMTP channel](/guide/notifications) configured for reports to be delivered.
+
+::: warning
+If SMTP delivery fails, the report is still recorded with status `failed` and the
+job **never aborts** — the failure is logged, but future months keep generating.
+A successfully sent report is recorded as `delivered`.
+:::
+
+## Enabling and disabling
+
+In the reports settings, toggle **Enabled** and set a **recipient email**. A valid
+recipient address is **required** whenever reports are enabled. Disabling the
+toggle stops future reports; already-generated history is kept.
+
+::: tip
+Use the **preview** to see the current in-progress month's numbers on demand — it
+is computed live and **not persisted**, so it never counts as the month's report.
+:::
+
+## Report history
+
+Past reports are listed newest-first (default 6, up to 50). Each history entry
+exposes `period`, `sentAt`, `status`, `uptimePct`, `incidentCount`,
+`downtimeSeconds`, `recipientEmail`, and the `resourceBreakdown` array.

--- a/nebula/guide/status-pages.md
+++ b/nebula/guide/status-pages.md
@@ -1,0 +1,70 @@
+# Status pages
+
+A **public status page** exposes your uptime to the outside world — customers,
+teammates, or a public audience — without giving anyone access to Ogoune itself.
+It aggregates your monitors and components into a single at-a-glance verdict, a
+per-monitor 90-day uptime bar, and a running incident history.
+
+The data behind it is served by a set of **unauthenticated** JSON endpoints under
+`/api/status`, so the page needs no API key and stays readable even while your
+admin UI is locked down.
+
+## What it shows
+
+- An **overall verdict** — `operational`, `partial_degradation`, or `major_outage` — derived from your monitors' current states.
+- **Components** grouping related monitors, each with its own aggregated state (`up`, `degraded`, `down`, `maintenance`, or `unknown`).
+- A **90-day uptime ribbon** per monitor (`uptime_90d_ratio` plus a day-by-day `uptime_ribbon`).
+- **Incidents** for the current month inline, with a full archive grouped by month.
+
+## The public API
+
+Fetch the live snapshot with a plain unauthenticated GET:
+
+```bash
+curl https://your-ogoune/api/status
+```
+
+```json
+{
+  "generated_at": "2026-08-03T09:00:00Z",
+  "verdict": { "status": "operational", "label": "All systems operational", "color": "#22c55e" },
+  "uptime_window": { "earliest_day": "2026-05-05", "latest_day": "2026-08-03" },
+  "components": [
+    {
+      "id": "01J…",
+      "name": "API",
+      "aggregated_state": "up",
+      "resources": [
+        { "id": "01J…", "name": "Public API", "host": "api.example.com", "current_state": "up", "uptime_90d_ratio": 0.9993 }
+      ]
+    }
+  ],
+  "standalone_resources": [],
+  "current_month_incidents": []
+}
+```
+
+Companion endpoints: `/api/status/incidents` (archive, `from`/`to`/`component_id`
+filters), `/api/status/incidents/{id}` (incident timeline),
+`/api/status/uptime` (daily aggregates, `from` + `to` required), and
+`/api/status/resource/{id}/windows` (24h / 7d / 30d / 90d rollups).
+
+::: tip
+Responses are short-cached (fresh for 60s, served stale up to 30s more), so a
+status page under load never hammers your database.
+:::
+
+::: warning
+Every monitor and component surfaced here is world-readable. Use component names
+and monitor labels that you're comfortable exposing publicly — the page is meant
+for customers, not internal detail.
+:::
+
+## Branding & custom domain
+
+Status page settings (name, homepage link, logos, favicon, primary color, and an
+optional custom domain) are managed in Ogoune under the status page settings. The
+public bundle is served as static assets, so you can also point a dedicated
+hostname like `status.yourdomain.com` at it.
+
+Next: [Incidents](/guide/incidents).

--- a/nebula/guide/tags-components.md
+++ b/nebula/guide/tags-components.md
@@ -1,0 +1,70 @@
+# Tags & components
+
+Ogoune gives you two ways to organise monitors. They sound similar but do very
+different jobs: a **tag** is a flat label for filtering, a **component** is a
+logical group with its own rolled-up status and alert de-duplication.
+
+## Tags — labels for filtering
+
+A tag is just a name plus two optional cosmetics: a `color` and a
+`description`. Attach the same tag to many monitors (`env:prod`, `team:payments`,
+`region:eu`) and use it to slice your monitor list. Tags carry **no health or
+alerting behaviour** — removing a tag never changes what gets checked or who
+gets paged.
+
+Manage them under `/api/v1/tags` (create, list, get, update, patch, delete).
+
+```bash
+curl -X POST https://your-ogoune/api/v1/tags \
+  -H "Authorization: Bearer $OGOUNE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "prod", "color": "#e11d48", "description": "Production surface"}'
+```
+
+## Components — grouped monitors with rolled-up status
+
+A component groups related monitors (say, everything behind "Checkout") into one
+unit with a **derived status**:
+
+- **down** — at least one member is `down` or `error`
+- **degraded** — at least one member is `warn`, `pending`, or `unknown`
+- **up** — everything else (paused members count as up)
+
+Unlike a tag, a component **must contain at least one resource** (`resource_ids`
+is required), and you can't delete one while resources are still attached — the
+API returns `409 COMPONENT_HAS_RESOURCES`. Move or detach members first (the
+bulk-assign / bulk-remove endpoints help).
+
+### Grouping window — one alert instead of many
+
+The `grouping_window_seconds` field is what makes a component more than a folder.
+When a shared dependency fails, its monitors often fall over within seconds of
+each other. With a grouping window set, Ogoune waits out a sliding timer before
+notifying, then sends **a single component-level alert** listing every impacted
+monitor — instead of one page per monitor.
+
+Set it to `0` to disable (immediate per-status notification), or any value
+**between 10 and 300 seconds**.
+
+```bash
+curl -X POST https://your-ogoune/api/v1/components \
+  -H "Authorization: Bearer $OGOUNE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Checkout",
+    "description": "Payment path",
+    "resource_ids": ["01H...", "01H...", "01H..."],
+    "grouping_window_seconds": 60
+  }'
+```
+
+::: tip
+Point notification channels at the component itself. When a resource belongs to a
+component, Ogoune resolves alerts through the component's channels — so the whole
+group routes to one place.
+:::
+
+::: warning
+The grouping window only affects **when and how alerts are batched**. It does not
+delay the checks themselves — monitor status still updates in real time.
+:::

--- a/nebula/package.json
+++ b/nebula/package.json
@@ -10,9 +10,12 @@
     "docs:preview": "vitepress preview"
   },
   "devDependencies": {
-    "vitepress": "^1.6.3"
+    "vitepress": "^1.6.3",
+    "vitepress-plugin-mermaid": "^2.0.17",
+    "debug": "^4.3.7"
   },
   "dependencies": {
-    "vitepress-openapi": "^0.2.1"
+    "vitepress-openapi": "^0.2.1",
+    "mermaid": "^11.4.1"
   }
 }

--- a/nebula/pnpm-lock.yaml
+++ b/nebula/pnpm-lock.yaml
@@ -8,13 +8,22 @@ importers:
 
   .:
     dependencies:
+      mermaid:
+        specifier: ^11.4.1
+        version: 11.16.0
       vitepress-openapi:
         specifier: ^0.2.1
         version: 0.2.1(vitepress@1.6.4(@algolia/client-search@5.55.1)(postcss@8.5.16)(search-insights@2.17.3))(vue@3.5.39)
     devDependencies:
+      debug:
+        specifier: ^4.3.7
+        version: 4.4.3
       vitepress:
         specifier: ^1.6.3
         version: 1.6.4(@algolia/client-search@5.55.1)(postcss@8.5.16)(search-insights@2.17.3)
+      vitepress-plugin-mermaid:
+        specifier: ^2.0.17
+        version: 2.0.17(mermaid@11.16.0)(vitepress@1.6.4(@algolia/client-search@5.55.1)(postcss@8.5.16)(search-insights@2.17.3))
 
 packages:
 
@@ -94,6 +103,9 @@ packages:
     resolution: {integrity: sha512-lCwXyijwPm3vbYHpBXPRomMcD6mgiptmps27gnMCf4HK+u/AOeFPBnIFh4V3l4A5SnP9VRiKBZqwGBpUH0vaTg==}
     engines: {node: '>= 14.0.0'}
 
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -110,6 +122,15 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@braintree/sanitize-url@6.0.4':
+    resolution: {integrity: sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==}
+
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@docsearch/css@3.8.2':
     resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
@@ -290,6 +311,9 @@ packages:
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
+  '@iconify/utils@3.1.4':
+    resolution: {integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==}
+
   '@internationalized/date@3.12.2':
     resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
 
@@ -298,6 +322,12 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@mermaid-js/mermaid-mindmap@9.3.0':
+    resolution: {integrity: sha512-IhtYSVBBRYviH1Ehu8gk69pMDF8DSRqXBRDMWrEfHoaMruHeaP2DXA3PBnuwsMaCdPQhlUUcy/7DBLAEIXvCAw==}
+
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
@@ -459,8 +489,104 @@ packages:
     peerDependencies:
       vue: ^2.7.0 || ^3.0.0
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.1':
+    resolution: {integrity: sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.4':
+    resolution: {integrity: sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -477,6 +603,9 @@ packages:
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -485,6 +614,9 @@ packages:
 
   '@ungap/structured-clone@1.3.2':
     resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitejs/plugin-vue@5.2.4':
     resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
@@ -624,15 +756,200 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   copy-anything@4.0.5:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -641,12 +958,18 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
+
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  es-toolkit@1.50.0:
+    resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -664,6 +987,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
@@ -676,9 +1002,39 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
   is-what@5.5.0:
     resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
     engines: {node: '>=18'}
+
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lucide-vue-next@1.0.0:
     resolution: {integrity: sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg==}
@@ -695,8 +1051,16 @@ packages:
   markdown-it-link-attributes@4.0.1:
     resolution: {integrity: sha512-pg5OK0jPLg62H4k7M9mRJLT61gUp9nvG0XveKYHMOOluASo9OEF13WlXrpAp2aj35LbedAy3QOCgQCw0tkLKAQ==}
 
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mermaid@11.16.0:
+    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
 
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
@@ -719,10 +1083,16 @@ packages:
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   nanoid@3.3.15:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  non-layered-tidy-tree-layout@2.0.2:
+    resolution: {integrity: sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==}
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
@@ -730,11 +1100,23 @@ packages:
   oniguruma-to-es@3.1.1:
     resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
 
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   postcss@8.5.16:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
@@ -763,10 +1145,22 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rollup@4.62.2:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   search-insights@2.17.3:
     resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
@@ -788,6 +1182,9 @@ packages:
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   superjson@2.2.6:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
     engines: {node: '>=16'}
@@ -795,8 +1192,16 @@ packages:
   tabbable@6.5.0:
     resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
 
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -815,6 +1220,10 @@ packages:
 
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -859,6 +1268,12 @@ packages:
     peerDependencies:
       vitepress: '>=1.0.0'
       vue: ^3.0.0
+
+  vitepress-plugin-mermaid@2.0.17:
+    resolution: {integrity: sha512-IUzYpwf61GC6k0XzfmAmNrLvMi9TRrVRMsUyCA8KNXhg/mQ1VqWnO0/tBVPiX5UoKF1mDUwqn5QV4qAJl6JnUg==}
+    peerDependencies:
+      mermaid: 10 || 11
+      vitepress: ^1.0.0 || ^1.0.0-alpha
 
   vitepress@1.6.4:
     resolution: {integrity: sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==}
@@ -1008,6 +1423,11 @@ snapshots:
     dependencies:
       '@algolia/client-common': 5.55.1
 
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.8.0
+      tinyexec: 1.3.0
+
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
@@ -1020,6 +1440,13 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@braintree/sanitize-url@6.0.4':
+    optional: true
+
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@chevrotain/types@11.1.2': {}
 
   '@docsearch/css@3.8.2': {}
 
@@ -1140,6 +1567,12 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
+  '@iconify/utils@3.1.4':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@internationalized/date@3.12.2':
     dependencies:
       '@swc/helpers': 0.5.23
@@ -1149,6 +1582,21 @@ snapshots:
       '@swc/helpers': 0.5.23
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@mermaid-js/mermaid-mindmap@9.3.0':
+    dependencies:
+      '@braintree/sanitize-url': 6.0.4
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      khroma: 2.1.0
+      non-layered-tidy-tree-layout: 2.0.2
+    optional: true
+
+  '@mermaid-js/parser@1.2.0':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
@@ -1276,7 +1724,126 @@ snapshots:
       '@tanstack/virtual-core': 3.17.3
       vue: 3.5.39
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.1':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.4': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.1
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/estree@1.0.9': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -1295,11 +1862,19 @@ snapshots:
 
   '@types/mdurl@2.0.0': {}
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@3.0.3': {}
 
   '@types/web-bluetooth@0.0.21': {}
 
   '@ungap/structured-clone@1.3.2': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vitejs/plugin-vue@5.2.4(vite@5.4.21)(vue@3.5.39)':
     dependencies:
@@ -1455,13 +2030,219 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   copy-anything@4.0.5:
     dependencies:
       is-what: 5.5.0
 
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
   csstype@3.2.3: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
+  dayjs@1.11.21: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   defu@6.1.7: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   dequal@2.0.3: {}
 
@@ -1469,9 +2250,15 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   emoji-regex-xs@1.0.0: {}
 
   entities@7.0.1: {}
+
+  es-toolkit@1.50.0: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -1508,6 +2295,8 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  hachure-fill@0.5.2: {}
+
   hast-util-to-html@9.0.5:
     dependencies:
       '@types/hast': 3.0.4
@@ -1530,7 +2319,29 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  import-meta-resolve@4.2.0: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
+
   is-what@5.5.0: {}
+
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
+  khroma@2.1.0: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
+
+  lodash-es@4.18.1: {}
 
   lucide-vue-next@1.0.0(vue@3.5.39):
     dependencies:
@@ -1544,6 +2355,8 @@ snapshots:
 
   markdown-it-link-attributes@4.0.1: {}
 
+  marked@16.4.2: {}
+
   mdast-util-to-hast@13.2.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -1555,6 +2368,30 @@ snapshots:
       unist-util-position: 5.0.0
       unist-util-visit: 5.1.0
       vfile: 6.0.3
+
+  mermaid@11.16.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.4
+      '@mermaid-js/parser': 1.2.0
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.12
+      es-toolkit: 1.50.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 14.0.1
 
   micromark-util-character@2.1.1:
     dependencies:
@@ -1577,7 +2414,12 @@ snapshots:
 
   mitt@3.0.1: {}
 
+  ms@2.1.3: {}
+
   nanoid@3.3.15: {}
+
+  non-layered-tidy-tree-layout@2.0.2:
+    optional: true
 
   ohash@2.0.11: {}
 
@@ -1587,9 +2429,20 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  package-manager-detector@1.8.0: {}
+
+  path-data-parser@0.1.0: {}
+
   perfect-debounce@1.0.0: {}
 
   picocolors@1.1.1: {}
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postcss@8.5.16:
     dependencies:
@@ -1629,6 +2482,8 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  robust-predicates@3.0.3: {}
+
   rollup@4.62.2:
     dependencies:
       '@types/estree': 1.0.9
@@ -1660,6 +2515,17 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
+  rw@1.3.3: {}
+
+  safer-buffer@2.1.2: {}
+
   search-insights@2.17.3: {}
 
   shiki@2.5.0:
@@ -1684,13 +2550,19 @@ snapshots:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
 
+  stylis@4.4.0: {}
+
   superjson@2.2.6:
     dependencies:
       copy-anything: 4.0.5
 
   tabbable@6.5.0: {}
 
+  tinyexec@1.3.0: {}
+
   trim-lines@3.0.1: {}
+
+  ts-dedent@2.3.0: {}
 
   tslib@2.8.1: {}
 
@@ -1716,6 +2588,8 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
+
+  uuid@14.0.1: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -1747,6 +2621,13 @@ snapshots:
       vue: 3.5.39
     transitivePeerDependencies:
       - '@vue/composition-api'
+
+  vitepress-plugin-mermaid@2.0.17(mermaid@11.16.0)(vitepress@1.6.4(@algolia/client-search@5.55.1)(postcss@8.5.16)(search-insights@2.17.3)):
+    dependencies:
+      mermaid: 11.16.0
+      vitepress: 1.6.4(@algolia/client-search@5.55.1)(postcss@8.5.16)(search-insights@2.17.3)
+    optionalDependencies:
+      '@mermaid-js/mermaid-mindmap': 9.3.0
 
   vitepress@1.6.4(@algolia/client-search@5.55.1)(postcss@8.5.16)(search-insights@2.17.3):
     dependencies:

--- a/nebula/self-host/observability.md
+++ b/nebula/self-host/observability.md
@@ -1,0 +1,76 @@
+# Observability
+
+Ogoune exposes a **Prometheus metrics endpoint** so you can scrape your monitoring
+data into Prometheus and chart it in Grafana. It publishes both operational
+metrics (check latency, throughput) and business metrics (which resources are up,
+how many incidents are open, rolling uptime ratios) — the same numbers the
+dashboard shows, in a form your own stack can alert on.
+
+The endpoint is **off by default**. Enable it with two environment variables:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `ENABLE_METRICS` | `false` | Turn the `/metrics` endpoint on. |
+| `METRICS_TOKEN` | *(empty)* | Bearer token required to scrape. |
+
+When `ENABLE_METRICS=true` and `METRICS_TOKEN` is set, Ogoune serves
+`/metrics` (unversioned, at the server root) and requires
+`Authorization: Bearer <token>`.
+
+::: warning
+If you enable metrics without setting `METRICS_TOKEN`, the endpoint is served
+**unauthenticated** — Ogoune logs a warning at startup. Metrics include resource
+names; always set a token, or restrict `/metrics` at the network/reverse-proxy
+layer.
+:::
+
+## Exposed metrics
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `ogoune_resource_up` | gauge | `id`, `name`, `type` | 1 = up, 0 = down. |
+| `ogoune_resource_status` | gauge | `id`, `name`, `type` | 0=unknown, 1=up, 2=down, 3=paused. |
+| `ogoune_incidents_total` | gauge | `id`, `name`, `type` | All-time incidents for the resource. |
+| `ogoune_incidents_active` | gauge | `id`, `name`, `type` | Currently open incidents. |
+| `ogoune_uptime_ratio` | gauge | `id`, `name`, `type`, `window` | Uptime % (0–100); `window` is `24h`, `7d`, or `30d`. |
+| `ogoune_check_duration_seconds` | histogram | `id`, `name`, `type` | Per-check latency. |
+| `ogoune_checks_total` | counter | `id`, `name`, `type`, `status` | Check executions by outcome. |
+
+Standard Go runtime and process collectors (`go_*`, `process_*`) are exported too.
+
+## Scrape it
+
+Check the endpoint with `curl`:
+
+```bash
+curl -H "Authorization: Bearer $METRICS_TOKEN" https://your-ogoune/metrics
+```
+
+Then point Prometheus at it:
+
+```yaml
+scrape_configs:
+  - job_name: ogoune
+    scheme: https
+    authorization:
+      type: Bearer
+      credentials: "your-metrics-token"
+    static_configs:
+      - targets: ["your-ogoune:8080"]
+```
+
+## Grafana dashboard & alert rules
+
+Ogoune can generate observability assets from your live configuration, served
+under the authenticated API (any operator API key, read-only is fine):
+
+- `GET /api/v1/integrations/grafana-dashboard` — a ready-to-import Grafana
+  dashboard JSON.
+- `GET /api/v1/integrations/alert-rules` — Prometheus alerting rules as YAML.
+  Pass `?uptimeThreshold=99` to set the uptime SLO the rules fire below.
+
+::: tip
+Import the dashboard JSON directly in Grafana (**Dashboards → Import**), and drop
+the rules file into your Prometheus `rule_files` — both stay in step with the
+resources you actually monitor.
+:::

--- a/roadmap.md
+++ b/roadmap.md
@@ -89,6 +89,8 @@ All contributors must sign our **CLA (Contributor Licence Agreement)** before th
 - [x] Two-factor authentication (TOTP)
 - [x] Maintenance windows (one-time + cron)
 - [x] Components, Tags, Organization
+- [x] YAML bulk import/export for resources
+- [x] Configurable dashboards — widget layout per view, scoped by tag/component/type/manual selection
 
 ---
 
@@ -117,6 +119,9 @@ Community Edition — expanding monitoring coverage, observability, and security
 
 - [x] **Public API v1** — versioned REST API with OpenAPI spec
 - [x] **Credential encryption (AES-256-GCM)** — SMTP passwords and webhook tokens encrypted at rest
+- [x] **Server-side search endpoint** — `GET /api/v1/search`, ranked cross-entity search
+  (monitors, incidents, app pages) powering the ⌘K command palette beyond the client-side window
+- [x] **Announcements** — operator-authored, dismissible in-app banners (info/warning/success/error)
 
 ---
 
@@ -139,12 +144,15 @@ Community Edition — expanding monitoring coverage, observability, and security
 
 ### Agent device monitoring — the killer feature
 
-- [ ] **Lightweight agent (Go)** — cross-platform device monitoring agent (Linux, macOS, Windows).
-  CPU, memory, disk, network metrics. Reverse tunnel pattern (agent initiates outbound connection), no
-  inbound ports required. Traverses NAT and Kubernetes Ingress natively. eBPF programs (via `cilium/ebpf`)
-  intercept kernel events on Linux — OOMKills, segfaults, syscall latency spikes — at the source.
-  Single language across backend + agent (shared domain types, protocol DTOs, tooling). Static stripped
-  binary target ≤15MB. **Community Edition.**
+- [x] **Lightweight agent (Go)** — cross-platform device monitoring agent (Linux, macOS, Windows),
+  shipped ahead of schedule in the v1.0.0-beta (specs 079-083). CPU, memory, per-mount disk, and network
+  metrics streamed over a WebSocket via a reverse tunnel (agent initiates outbound connection), no
+  inbound ports required. Single language across backend + agent (shared domain types via
+  `pkg/agentwire`). Ships as a distroless container image + static release binaries, with a systemd
+  unit and agent-down alerting. No eBPF/kernel-event interception yet — see below.
+- [ ] **Kernel-level event interception (eBPF)** — via `cilium/ebpf`, intercept kernel events on Linux
+  (OOMKills, segfaults, syscall latency spikes) at the source, feeding Flash Correlation below.
+  **Community Edition.**
   > **Note:** A Zig rewrite for sub-3MB footprint was previously planned but dropped. eBPF tooling is
   > mature in Go (Cilium, Datadog, Parca, Pixie all ship Go+eBPF in prod), Zig is pre-1.0 with weak
   > Windows/macOS coverage, and footprint <30MB is not a real adoption blocker — Flash Correlation is
@@ -165,8 +173,9 @@ Community Edition — expanding monitoring coverage, observability, and security
 
 ### Reporting
 
-- [ ] **Scheduled reports — Community** — monthly health report (fixed schedule, first day of the month).
-  Covers all resources. Sent via configured SMTP channel. Toggle on/off in settings. No configuration required.
+- [x] **Scheduled reports — Community** — monthly health report (fixed schedule, first day of the month),
+  shipped ahead of schedule in v1.0.0-beta. Covers all resources. Sent via configured SMTP channel.
+  Toggle on/off in settings. No configuration required.
 
 ### Alerting & integrations
 


### PR DESCRIPTION
## Summary
- 8 new nebula/ guide pages (status pages, dashboards, reports, tags/components, maintenance windows, API keys & 2FA, YAML import/export, Prometheus observability) — every shipped feature that previously had zero narrative docs, only auto-generated API reference
- `guide/monitor-types.md` rewritten with real per-type config examples (Heartbeat/Push, SSL/domain expiry, Protocol-with-auth)
- `enterprise/index.md` corrected — was misdescribing Postgres/Redis (Community Edition) as an EE differentiator; now lists real EE scope with an honest "still building" note
- `roadmap.md` drift fixed — reports & host agent were marked Planned despite shipping; dashboards/YAML import-export/announcements/search were shipped but missing entirely
- mermaid wired into nebula (incident lifecycle diagram), plus the pnpm strict-linking dep-resolution fix that surfaced (`nebula/.npmrc` hoist pattern + explicit `debug` devDependency)

## Test plan
- [x] `pnpm docs:build` — clean, no dead links, mermaid compiles
- [x] `pnpm docs:dev` — verified clean startup post dependency fix, all new pages return 200
- [x] Every doc claim grounded in Go source (DTOs/handlers/domain models), not roadmap prose — cross-checked during authoring