### PR TITLE
chore(release): v1.0.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.0.0-beta.3] - 2026-08-03
+
 ### Added
 
 - **Public docs coverage for previously-undocumented shipped features (`nebula/`)** — new

--- a/release-notes/v1.0.0-beta.3.md
+++ b/release-notes/v1.0.0-beta.3.md
@@ -1,0 +1,40 @@
+# Ogoune v1.0.0-beta.3
+
+A documentation-focused release: closes most of the gap between what's shipped and what's
+publicly documented at [docs.ogoune.com](https://docs.ogoune.com), and corrects drift in
+`roadmap.md`. No API or database changes.
+
+## Highlights
+
+**New documentation**
+
+- Status pages, dashboards, scheduled reports, tags & components, maintenance windows, API
+  keys & 2FA, bulk YAML import/export, and Prometheus observability (`/metrics` + the Grafana
+  dashboard / alert-rules endpoints) — all shipped features that previously had zero narrative
+  documentation, only an auto-generated API reference. Every page is grounded directly in the
+  v1 API and Go source.
+- `guide/monitor-types.md` rewritten with real per-type config examples, including the
+  previously-undocumented Heartbeat/Push, SSL/domain expiry, and Protocol-with-auth
+  (Redis/MySQL/PostgreSQL) variants.
+- Mermaid diagrams wired into the docs site — `guide/incidents.md` now has a state diagram of
+  the incident lifecycle.
+
+**Corrections**
+
+- `enterprise/index.md` no longer misdescribes PostgreSQL + Redis as an Enterprise Edition
+  differentiator — that's Community Edition (see `self-host/production.md`). It now lists the
+  actual EE scope (team management, SSO/SAML, multi-tenancy, SOC 2 audit logs, dedicated
+  support), with an honest note that most of it is still on the roadmap, not shipped.
+- `roadmap.md` drift fixed: scheduled reports and the host agent were marked Planned despite
+  already shipping; dashboards, YAML bulk import/export, announcements, and the search endpoint
+  were shipped but missing from the document entirely.
+
+## Upgrade notes
+
+- Documentation-only release. No database migration, no API changes.
+- If you run `nebula/` locally: `pnpm install` picks up the new mermaid dependency and a
+  `.npmrc` fix for a pnpm strict-linking issue in `vitepress-plugin-mermaid`.
+
+## Full changelog
+
+See [CHANGELOG.md](../CHANGELOG.md) → `[1.0.0-beta.3]`.


### PR DESCRIPTION
Release commit for v1.0.0-beta.3 — see release-notes/v1.0.0-beta.3.md and CHANGELOG.md.