### PR TITLE
fix(web): release build type-check fix, bump v1.0.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ follows [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.0.0-beta.4] - 2026-08-03
+
+### Fixed
+
+- **`useNotificationChannels` spec type errors** — `web/src/composables/__tests__/useNotificationChannels.spec.ts`
+  passed a bare `{}` for `NotificationConfig` in two call sites, failing `vue-tsc --build` in the
+  release image build (`v1.0.0-beta.3`'s Docker build never completed). Cast to `SlackConfig`,
+  matching the `type: 'slack'` fixtures. Pre-existing since spec 086 US3 (PR #59), unrelated to
+  the `nebula/` docs work in beta.3.
+
 ## [1.0.0-beta.3] - 2026-08-03
 
 ### Added

--- a/release-notes/v1.0.0-beta.4.md
+++ b/release-notes/v1.0.0-beta.4.md
@@ -1,0 +1,33 @@
+# Ogoune v1.0.0-beta.4
+
+A build-fix release. `v1.0.0-beta.3`'s Docker image build failed at the frontend type-check
+step, so no image or GitHub Release was ever published for that tag. This release contains the
+same content as beta.3 plus the fix. No API or database changes.
+
+## Highlights
+
+**Fixed**
+
+- `web/src/composables/__tests__/useNotificationChannels.spec.ts` passed a bare `{}` where a
+  `NotificationConfig` was expected, failing `vue-tsc --build` inside the release Docker build.
+  Cast to `SlackConfig`. Pre-existing since spec 086 US3 (PR #59), unrelated to the beta.3
+  documentation work.
+
+**Carried over from beta.3**
+
+- New `nebula/` documentation: status pages, dashboards, scheduled reports, tags & components,
+  maintenance windows, API keys & 2FA, bulk YAML import/export, Prometheus observability.
+- `guide/monitor-types.md` rewritten with real per-type config examples.
+- Mermaid diagrams wired into the docs site.
+- `enterprise/index.md` corrected (PostgreSQL + Redis are Community Edition, not EE).
+- `roadmap.md` drift fixed.
+
+## Upgrade notes
+
+- No database migration, no API changes.
+- If you run `nebula/` locally: `pnpm install` picks up the new mermaid dependency and a
+  `.npmrc` fix for a pnpm strict-linking issue in `vitepress-plugin-mermaid`.
+
+## Full changelog
+
+See [CHANGELOG.md](../CHANGELOG.md) → `[1.0.0-beta.4]`.

--- a/web/src/composables/__tests__/useNotificationChannels.spec.ts
+++ b/web/src/composables/__tests__/useNotificationChannels.spec.ts
@@ -17,6 +17,7 @@ vi.mock('@/services/notificationChannelService', () => ({
 }))
 
 import { useNotificationChannels } from '../useNotificationChannels'
+import type { SlackConfig } from '@/types'
 
 beforeEach(() => {
   fetchChannelsMock.mockReset()
@@ -51,7 +52,12 @@ describe('useNotificationChannels', () => {
     createChannelMock.mockResolvedValue({ id: 'new', name: 'N', type: 'slack', config: {} })
     const c = useNotificationChannels()
     await c.loadChannels()
-    const created = await c.addChannel({ name: 'N', type: 'slack', config: {}, enabled_by_default: false })
+    const created = await c.addChannel({
+      name: 'N',
+      type: 'slack',
+      config: {} as SlackConfig,
+      enabled_by_default: false,
+    })
     expect(created.id).toBe('new')
     expect(c.channels.value.map((x) => x.id)).toEqual(['new'])
   })
@@ -81,7 +87,7 @@ describe('useNotificationChannels', () => {
     testChannelConfigMock.mockResolvedValue(undefined)
     const c = useNotificationChannels()
     await c.testChannel('a')
-    await c.testChannelConfig({ type: 'slack', config: {} })
+    await c.testChannelConfig({ type: 'slack', config: {} as SlackConfig })
     expect(testChannelMock).toHaveBeenCalledWith('a')
     expect(testChannelConfigMock).toHaveBeenCalledWith({ type: 'slack', config: {} })
   })


### PR DESCRIPTION
## Summary
- v1.0.0-beta.3's release Docker build failed at `vue-tsc --build` (pre-existing test-fixture type error, unrelated to the beta.3 docs work) — no image/GitHub Release was ever published for that tag.
- Fixes `useNotificationChannels.spec.ts` (cast `{}` to `SlackConfig`).
- Bumps to v1.0.0-beta.4 (CHANGELOG + release-notes).

## Test plan
- [x] `pnpm type-check` clean
- [x] `pnpm exec vitest run src/composables/__tests__/useNotificationChannels.spec.ts` — 6/6 pass